### PR TITLE
chore: update dependencies and fix dark mode theming

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -8,7 +8,6 @@
              RequestedThemeVariant="Dark">
     <Application.Styles>
         <fa:FluentAvaloniaTheme />
-        
         <!-- Global Control Styles -->
         <Style Selector="TextBox">
             <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -34,7 +33,6 @@
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
         </Style>
-        
         <Style Selector="Border.dialog">
             <Setter Property="Background" Value="{DynamicResource SolidBackgroundFillColorBase}"/>
             <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}"/>
@@ -42,7 +40,6 @@
             <Setter Property="CornerRadius" Value="8"/>
             <Setter Property="Padding" Value="16"/>
         </Style>
-        
         <!-- Reusable Button Styles for Icon+Text patterns -->
         <Style Selector="Button.IconText">
             <Setter Property="Height" Value="40"/>
@@ -50,14 +47,12 @@
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="Padding" Value="12,0"/>
         </Style>
-        
         <Style Selector="Button.IconTextLarge">
             <Setter Property="Height" Value="50"/>
             <Setter Property="HorizontalContentAlignment" Value="Left"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="Padding" Value="16,0"/>
         </Style>
-        
         <!-- Centered Icon+Text Button (for Welcome page) -->
         <Style Selector="Button.IconTextCentered">
             <Setter Property="Height" Value="50"/>
@@ -65,14 +60,14 @@
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="Padding" Value="16,0"/>
         </Style>
-        
         <!-- Icon Only Button (for Settings, etc.) -->
         <Style Selector="Button.IconOnly">
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="Padding" Value="0"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Background" Value="Transparent"/>
         </Style>
-        
         <!--
             Icon styles - Cross-platform vertical centering fix
 
@@ -84,7 +79,7 @@
             as icons may have custom FontSize values that need to scale naturally.
         -->
 
-        <!-- Default: Standard icon with right margin for icon+text spacing -->
+        <!-- Default: Standard icon styling -->
         <Style Selector="fi|SymbolIcon">
             <Setter Property="FontSize" Value="16"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
@@ -92,9 +87,24 @@
             <Setter Property="Margin" Value="0,0,8,0"/>
         </Style>
 
-        <!-- NavBar override: No right margin (uses StackPanel Spacing) -->
+        <!-- Ensure icons inherit theme foreground in all common containers -->
         <Style Selector="ListBoxItem fi|SymbolIcon">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
             <Setter Property="Margin" Value="0"/>
+        </Style>
+        <Style Selector="Button fi|SymbolIcon">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        </Style>
+        <Style Selector="StackPanel fi|SymbolIcon">
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
+        </Style>
+
+        <!-- Accent button: white text/icons on Teams purple background -->
+        <Style Selector="Button.accent fi|SymbolIcon">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Button.accent TextBlock">
+            <Setter Property="Foreground" Value="White"/>
         </Style>
 
         <!-- IconOnly override: No margin (centered in button) -->
@@ -155,12 +165,10 @@
             <Setter Property="Margin" Value="0,0,0,16"/>
         </Style>
     </Application.Styles>
-    
     <Application.Resources>
         <!-- Value Converters -->
         <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
-        
         <!-- Note: Icon geometries removed - now using FluentIcons.Avalonia SymbolIcon -->
 
         <!-- Teams Violet Color Palette -->

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -24,6 +24,12 @@
             <Setter Property="Background" Value="{DynamicResource TeamsPrimaryBrush}"/>
             <Setter Property="Padding" Value="16"/>
         </Style>
+        <Style Selector="Border.header TextBlock">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style Selector="Border.header fi|SymbolIcon">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
     </Window.Styles>
 
     <Grid x:Name="MainGrid">
@@ -36,24 +42,19 @@
         <!-- Top Bar -->
         <Border Grid.Row="0" Classes="header">
             <DockPanel LastChildFill="False">
-                <TextBlock Text="Teams Phone Manager" 
+                <TextBlock Text="Teams Phone Manager"
                          FontSize="18"
                          FontWeight="SemiBold"
-                         VerticalAlignment="Center"
-                         Foreground="White"/>
+                         VerticalAlignment="Center"/>
                 <Button x:Name="SettingsButton"
-                        DockPanel.Dock="Right" 
+                        DockPanel.Dock="Right"
                         Command="{Binding ToggleSettingsCommand}"
-                        Background="Transparent"
-                        Foreground="White"
                         Width="40"
                         Height="40"
                         Classes="IconOnly"
                         AutomationProperties.Name="Settings"
                         ToolTip.Tip="Settings">
-                    <fi:SymbolIcon 
-                              Symbol="Settings"
-                              Foreground="White"/>
+                    <fi:SymbolIcon Symbol="Settings"/>
                 </Button>
             </DockPanel>
         </Border>
@@ -71,7 +72,6 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                
                 <ListBox x:Name="NavigationListBox" Grid.Column="0" Classes="nav"
                          SelectionChanged="NavigationListBox_SelectionChanged">
                     <ListBoxItem Tag="Welcome" Classes="nav" AutomationProperties.Name="Welcome">
@@ -144,7 +144,6 @@
                         </StackPanel>
                     </ListBoxItem>
                 </ListBox>
-                
                 <Border Grid.Column="1"
                         Background="{DynamicResource DividerStrokeColorDefaultBrush}"
                         Width="1"
@@ -272,8 +271,6 @@
                         <fi:SymbolIcon Grid.Column="0"
                                   FontSize="16"
                                   Symbol="Code"
-                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-
                                   VerticalAlignment="Center"/>
                         <TextBlock Grid.Column="1"
                                  Text="{Binding LatestLogEntry}"
@@ -284,7 +281,6 @@
                         <fi:SymbolIcon Grid.Column="2"
                                   FontSize="14"
                                   Symbol="ChevronRight"
-                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                   Margin="8,0,0,0"
                                   Opacity="0.6"
                                   VerticalAlignment="Center"/>
@@ -329,31 +325,23 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        
                         <!-- Dialog Header -->
                         <Border Grid.Row="0" Classes="header" Padding="16">
                             <DockPanel LastChildFill="False">
-                                <TextBlock Text="Log Viewer" 
-                                         
+                                <TextBlock Text="Log Viewer"
                                          FontWeight="SemiBold"
-                                         Foreground="White"
                                          VerticalAlignment="Center"/>
-                                <Button DockPanel.Dock="Right" 
-                                        Background="Transparent"
-                                        Foreground="White"
+                                <Button DockPanel.Dock="Right"
                                         Command="{Binding CloseLogDialogCommand}"
                                         Width="40"
                                         Height="40"
                                         Classes="IconOnly"
                                         AutomationProperties.Name="Close Log Viewer"
                                         ToolTip.Tip="Close">
-                                    <fi:SymbolIcon 
-                                             Symbol="Dismiss"
-                                             Foreground="White"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                 </Button>
                             </DockPanel>
                         </Border>
-                        
                         <!-- Log Content -->
                         <ScrollViewer x:Name="LogScrollViewer"
                                     Grid.Row="1"
@@ -379,7 +367,6 @@
                                 </TextBox.ContextMenu>
                             </TextBox>
                         </ScrollViewer>
-                        
                         <!-- Dialog Footer -->
                         <StackPanel Grid.Row="2" 
                                    Orientation="Horizontal" 
@@ -389,20 +376,14 @@
                             <Button Command="{Binding ClearLogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon FontSize="16"
-                                             Symbol="Delete"
-                                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                             />
+                                    <fi:SymbolIcon FontSize="16" Symbol="Delete"/>
                                     <TextBlock Text="Clear Log" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding CloseLogDialogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon FontSize="16"
-                                             Symbol="Dismiss"
-                                             Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                             />
+                                    <fi:SymbolIcon FontSize="16" Symbol="Dismiss"/>
                                     <TextBlock Text="Close" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -434,7 +415,6 @@
                 </Style>
             </Border.Styles>
         </Border>
-        
         <!-- Side panel -->
         <Border Grid.RowSpan="3"
                 Background="{DynamicResource SolidBackgroundFillColorBase}"
@@ -451,31 +431,24 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                
                 <!-- Header -->
                 <Border Grid.Row="0" Classes="header" Padding="24,16">
                     <DockPanel LastChildFill="False">
-                        <TextBlock Text="Settings" 
+                        <TextBlock Text="Settings"
                                  FontSize="18"
                                  FontWeight="SemiBold"
-                                 Foreground="White"
                                  VerticalAlignment="Center"/>
                         <Button DockPanel.Dock="Right" 
-                                Background="Transparent"
-                                Foreground="White"
                                 Command="{Binding CloseSettingsCommand}"
                                 Width="36"
                                 Height="36"
                                 Classes="IconOnly"
                                 AutomationProperties.Name="Close Settings"
                                 ToolTip.Tip="Close">
-                            <fi:SymbolIcon 
-                                     Symbol="Dismiss"
-                                     Foreground="White"/>
+                            <fi:SymbolIcon Symbol="Dismiss"/>
                         </Button>
                     </DockPanel>
                 </Border>
-                
                 <!-- Content -->
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                     <StackPanel Margin="24,20" Spacing="20">

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using teams_phonemanager.Services;
@@ -80,7 +79,6 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .LogToTrace()
-            .UseReactiveUI();
+            .LogToTrace();
 }
 

--- a/Services/PowerShellContextService.cs
+++ b/Services/PowerShellContextService.cs
@@ -29,7 +29,12 @@ namespace teams_phonemanager.Services
                 // Setting it here instead of calling Set-ExecutionPolicy at runtime avoids triggering
                 // AV behavioral heuristics (Kaspersky flags runtime Set-ExecutionPolicy Bypass as MITRE T1059.001).
                 var initialState = InitialSessionState.CreateDefault();
-                initialState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
+                // ExecutionPolicy is Windows-only; setting it on macOS/Linux throws
+                // PlatformNotSupportedException in PowerShell SDK 7.6+.
+                if (OperatingSystem.IsWindows())
+                {
+                    initialState.ExecutionPolicy = Microsoft.PowerShell.ExecutionPolicy.Bypass;
+                }
                 localRunspace = RunspaceFactory.CreateRunspace(initialState);
                 localRunspace.Open();
 

--- a/Views/AutoAttendantsView.axaml
+++ b/Views/AutoAttendantsView.axaml
@@ -11,7 +11,6 @@
              x:Class="teams_phonemanager.Views.AutoAttendantsView"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <!-- DataContext is set via data binding from MainWindow -->
 
     <UserControl.Resources>
@@ -56,7 +55,6 @@
 
                 <!-- Tab Control -->
                 <TabControl Grid.Row="2" >
-                    
                     <!-- Resource Accounts Tab -->
                     <TabItem Header="Resource Accounts">
                         <Grid Margin="16">
@@ -77,20 +75,18 @@
 
                                 <Button Grid.Column="0"
                                         Command="{Binding RetrieveResourceAccountsCommand}"
-                                        
                                         Margin="0,0,16,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="ArrowSync" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="ArrowSync"/>
                                         <TextBlock Text="Retrieve Accounts" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
 
                                 <Button Grid.Column="1"
                                         Command="{Binding OpenCreateResourceAccountDialogCommand}"
-                                        
                                         Margin="0,0,8,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="PersonAdd"/>
                                         <TextBlock Text="Create Account" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -160,20 +156,18 @@
 
                                 <Button Grid.Column="0"
                                         Command="{Binding RetrieveAutoAttendantsCommand}"
-                                        
                                         Margin="0,0,16,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="ArrowSync" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="ArrowSync"/>
                                         <TextBlock Text="Retrieve Auto Attendants" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
 
                                 <Button Grid.Column="1"
                                         Command="{Binding OpenCreateAutoAttendantDialogCommand}"
-                                        
                                         Margin="0,0,8,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="CallInbound" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="CallInbound"/>
                                         <TextBlock Text="Create Auto Attendant" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -204,9 +198,7 @@
                                       IsReadOnly="True"
                                       GridLinesVisibility="None"
                                       SelectionMode="Single"
-                                      
                                       HorizontalScrollBarVisibility="Auto"
-                                      
                                       >
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="2*"/>
@@ -250,7 +242,7 @@
                                                 Command="{Binding OpenCreateResourceAccountDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="PersonAdd"/>
                                                 <TextBlock Text="Create Resource Account" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -272,7 +264,7 @@
                                                 Command="{Binding OpenUpdateUsageLocationDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Location" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Location"/>
                                                 <TextBlock Text="Update Usage Location" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -294,7 +286,7 @@
                                                 Command="{Binding AssignLicenseCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Certificate" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Certificate"/>
                                                 <TextBlock Text="Assign License" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -316,7 +308,7 @@
                                                 Command="{Binding OpenValidateCallQueueDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Person" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Person"/>
                                                 <TextBlock Text="Validate Call Queue Account" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -338,7 +330,7 @@
                                                 Command="{Binding OpenCreateCallTargetDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="PersonArrowRight" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="PersonArrowRight"/>
                                                 <TextBlock Text="Create Call Target" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -360,7 +352,7 @@
                                                 Command="{Binding OpenCreateDefaultCallFlowDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="CallForward" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="CallForward"/>
                                                 <TextBlock Text="Create Default Call Flow" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -382,7 +374,7 @@
                                                 Command="{Binding OpenCreateAfterHoursCallFlowDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="CallEnd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="CallEnd"/>
                                                 <TextBlock Text="Create After Hours Call Flow" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -404,7 +396,7 @@
                                                 Command="{Binding OpenCreateAfterHoursScheduleDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Clock" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Clock"/>
                                                 <TextBlock Text="Create After Hours Schedule" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -426,7 +418,7 @@
                                                 Command="{Binding OpenCreateCallHandlingAssociationDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Link"/>
                                                 <TextBlock Text="Create Call Handling Association" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -448,7 +440,7 @@
                                                 Command="{Binding OpenCreateAutoAttendantDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="CallInbound" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="CallInbound"/>
                                                 <TextBlock Text="Create Auto Attendant" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -470,7 +462,7 @@
                                                 Command="{Binding OpenAssociateDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Link"/>
                                                 <TextBlock Text="Associate Account" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -516,40 +508,36 @@
                         <StackPanel>
                         <TextBlock Text="Create Resource Account"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Display Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountDisplayName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="The values are auto-generated from your variables. You can modify them if needed."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateResourceAccountDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateResourceAccountCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="PersonAdd"/>
                                     <TextBlock Text="Create Account" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -584,7 +572,6 @@
                         <StackPanel>
                         <TextBlock Text="Update Usage Location"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Resource Account UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
@@ -592,26 +579,24 @@
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                IsReadOnly="True"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will update the usage location for the resource account. The value is taken from your variables."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseUpdateUsageLocationDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding UpdateUsageLocationCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Location" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Location"/>
                                     <TextBlock Text="Update Location" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -646,33 +631,30 @@
                         <StackPanel>
                         <TextBlock Text="Create Auto Attendant"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Auto Attendant Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding AutoAttendantName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="The auto attendant name is auto-generated from your variables. Make sure to validate the Call Queue resource account before creating the auto attendant."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateAutoAttendantDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateAutoAttendantCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CallInbound" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CallInbound"/>
                                     <TextBlock Text="Create Auto Attendant" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -707,40 +689,36 @@
                         <StackPanel>
                         <TextBlock Text="Associate Resource Account with Auto Attendant"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Resource Account UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Auto Attendant Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding AutoAttendantName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will associate the resource account with the auto attendant to complete the setup."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseAssociateDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding AssociateResourceAccountWithAutoAttendantCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Link"/>
                                     <TextBlock Text="Associate" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -775,33 +753,30 @@
                         <StackPanel>
                         <TextBlock Text="Validate Call Queue Resource Account"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Call Queue Resource Account UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding CallQueueUpn}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will validate that the Call Queue resource account exists and can be used as the call target for the auto attendant. The value is auto-generated from your variables, but you can modify it if needed."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseValidateCallQueueDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding ValidateCallQueueResourceAccountCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Person" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Person"/>
                                     <TextBlock Text="Validate Account" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -836,26 +811,24 @@
                         <StackPanel>
                         <TextBlock Text="Create Call Target"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="This will create the callable entity that will be used as the call target for the auto attendant."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateCallTargetDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateCallTargetCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="PersonArrowRight" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="PersonArrowRight"/>
                                     <TextBlock Text="Create Call Target" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -890,26 +863,24 @@
                         <StackPanel>
                         <TextBlock Text="Create Default Call Flow"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="This will create the default call flow with menu options for the auto attendant."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateDefaultCallFlowDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateDefaultCallFlowCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CallForward" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CallForward"/>
                                     <TextBlock Text="Create Default Call Flow" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -944,26 +915,24 @@
                         <StackPanel>
                         <TextBlock Text="Create After Hours Call Flow"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="This will create the after hours call flow with disconnect option."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateAfterHoursCallFlowDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateAfterHoursCallFlowCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CallEnd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CallEnd"/>
                                     <TextBlock Text="Create After Hours Call Flow" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -998,26 +967,24 @@
                         <StackPanel>
                         <TextBlock Text="Create After Hours Schedule"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="This will create the schedule that defines when the after hours call flow should be active."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateAfterHoursScheduleDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateAfterHoursScheduleCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Clock" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Clock"/>
                                     <TextBlock Text="Create After Hours Schedule" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -1052,26 +1019,24 @@
                         <StackPanel>
                         <TextBlock Text="Create Call Handling Association"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="This will associate the after hours schedule with the after hours call flow."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateCallHandlingAssociationDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateCallHandlingAssociationCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Link"/>
                                     <TextBlock Text="Create Call Handling Association" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -1088,9 +1053,7 @@
                            Value="0"
                            IsIndeterminate="True"
                            Width="50"
-                           
                            Margin="0,16,0,0"/>
-                
                 <!-- Waiting Message -->
                 <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
                            FontSize="14"

--- a/Views/BulkOperationsView.axaml
+++ b/Views/BulkOperationsView.axaml
@@ -36,31 +36,31 @@
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <Button Command="{Binding ExportTemplateFileCommand}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="ArrowDownload" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="ArrowDownload"/>
                                 <TextBlock Text="Download Template" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding ImportCsvFileCommand}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="ArrowUpload" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="ArrowUpload"/>
                                 <TextBlock Text="Import CSV" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding GenerateTemplateCommand}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="DocumentAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="DocumentAdd"/>
                                 <TextBlock Text="Generate Template" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding ParseCsvCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="TableSearch" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="TableSearch"/>
                                 <TextBlock Text="Parse CSV" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding PreviewScriptCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="Eye" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="Eye"/>
                                 <TextBlock Text="Preview Script" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
@@ -68,7 +68,7 @@
                                 Classes="IconText"
                                 IsEnabled="{Binding !IsBusy}">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="Play" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="Play"/>
                                 <TextBlock Text="Execute All" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
@@ -80,7 +80,6 @@
                              FontSize="13"
                              Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                              IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-                    
                     <!-- Progress -->
                     <ProgressBar IsIndeterminate="True"
                                  IsVisible="{Binding IsExecuting}"
@@ -89,7 +88,6 @@
 
                 <!-- Content Tabs -->
                 <TabControl Grid.Row="1" Margin="24,0,24,24">
-                    
                     <!-- CSV Editor Tab -->
                     <TabItem Header="CSV Data">
                         <Border Background="{DynamicResource ControlFillColorDefaultBrush}"

--- a/Views/CallQueuesView.axaml
+++ b/Views/CallQueuesView.axaml
@@ -11,7 +11,6 @@
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <!-- DataContext is set via data binding from MainWindow -->
 
     <UserControl.Resources>
@@ -55,7 +54,6 @@
 
                 <!-- Tab Control -->
                 <TabControl Grid.Row="2">
-                    
                     <!-- Resource Accounts Tab -->
                     <TabItem Header="Resource Accounts">
                         <Grid Margin="16">
@@ -80,7 +78,7 @@
                                         AutomationProperties.Name="Retrieve Resource Accounts"
                                         Margin="0,0,16,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="ArrowSync" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="ArrowSync"/>
                                         <TextBlock Text="Retrieve Accounts" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -91,7 +89,7 @@
                                         AutomationProperties.Name="Create Resource Account"
                                         Margin="0,0,8,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="PersonAdd"/>
                                         <TextBlock Text="Create Account" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -167,7 +165,7 @@
                                         AutomationProperties.Name="Retrieve Call Queues"
                                         Margin="0,0,16,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="ArrowSync" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="ArrowSync"/>
                                         <TextBlock Text="Retrieve Queues" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -178,7 +176,7 @@
                                         AutomationProperties.Name="Create Call Queue"
                                         Margin="0,0,8,0" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="CallAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="CallAdd"/>
                                         <TextBlock Text="Create Queue" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -254,7 +252,7 @@
                                                 Command="{Binding OpenCreateResourceAccountDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="PersonAdd"/>
                                                 <TextBlock Text="Create Resource Account" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -276,7 +274,7 @@
                                                 Command="{Binding OpenUpdateUsageLocationDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Location" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Location"/>
                                                 <TextBlock Text="Update Usage Location" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -298,7 +296,7 @@
                                                 Command="{Binding AssignLicenseCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Certificate" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Certificate"/>
                                                 <TextBlock Text="Assign License" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -320,7 +318,7 @@
                                                 Command="{Binding GetM365GroupIdCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="PersonSearch" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="PersonSearch"/>
                                                 <TextBlock Text="Get M365 Group ID" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -342,7 +340,7 @@
                                                 Command="{Binding OpenCreateCallQueueDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                     <StackPanel Orientation="Horizontal">
-                        <fi:SymbolIcon  Symbol="CallAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                        <fi:SymbolIcon  Symbol="CallAdd"/>
                         <TextBlock Text="Create Call Queue" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -364,7 +362,7 @@
                                                 Command="{Binding OpenAssociateDialogCommand}"
                                                 HorizontalAlignment="Left" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Link"/>
                                                 <TextBlock Text="Associate Account" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -401,40 +399,36 @@
                         <StackPanel>
                         <TextBlock Text="Create Resource Account"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Display Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountDisplayName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="The values are auto-generated from your variables. You can modify them if needed."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateResourceAccountDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateResourceAccountCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="PersonAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="PersonAdd"/>
                                     <TextBlock Text="Create Account" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -469,7 +463,6 @@
                         <StackPanel>
                         <TextBlock Text="Update Usage Location"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Resource Account UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
@@ -477,26 +470,24 @@
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                IsReadOnly="True"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will update the usage location for the resource account. The value is taken from your variables."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseUpdateUsageLocationDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding UpdateUsageLocationCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Location" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Location"/>
                                     <TextBlock Text="Update Location" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -531,14 +522,12 @@
                         <StackPanel>
                         <TextBlock Text="Create Call Queue"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Call Queue Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding CallQueueName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="M365 Group ID:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
@@ -550,26 +539,24 @@
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="The call queue name is auto-generated from your variables. Use the 'Get M365 Group ID' button to retrieve the Group ID."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateCallQueueDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateCallQueueCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CallAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CallAdd"/>
                                     <TextBlock Text="Create Queue" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -604,40 +591,36 @@
                         <StackPanel>
                         <TextBlock Text="Associate Resource Account with Call Queue"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Resource Account UPN:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding ResourceAccountUpn}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Call Queue Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding CallQueueName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will associate the resource account with the call queue to complete the setup."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseAssociateDialogCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding AssociateResourceAccountWithCallQueueCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Link"/>
                                     <TextBlock Text="Associate" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -659,7 +642,6 @@
                                IsIndeterminate="True"
                                Width="50"
                                Margin="0,0,0,16"/>
-                
                     <!-- Waiting Message -->
                     <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
                                FontSize="14"

--- a/Views/DocumentationView.axaml
+++ b/Views/DocumentationView.axaml
@@ -38,7 +38,7 @@
                                 Classes="IconText"
                                 IsEnabled="{Binding !IsBusy}">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="ArrowDownload" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="ArrowDownload"/>
                                 <TextBlock Text="Export Documentation" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
@@ -47,7 +47,7 @@
                                 Classes="IconText"
                                 IsEnabled="{Binding !IsBusy}">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="Copy" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="Copy"/>
                                 <TextBlock Text="Copy to Clipboard" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
@@ -59,7 +59,6 @@
                              FontSize="13"
                              Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                              IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-                    
                     <!-- Progress indicator -->
                     <ProgressBar IsIndeterminate="True"
                                  IsVisible="{Binding IsExporting}"

--- a/Views/GetStartedView.axaml
+++ b/Views/GetStartedView.axaml
@@ -9,7 +9,6 @@
              x:Class="teams_phonemanager.Views.GetStartedView"
              mc:Ignorable="d" 
              d:DesignHeight="800" d:DesignWidth="1000">
-    
     <!-- DataContext is set via data binding from MainWindow -->
 
     <UserControl.Resources>
@@ -60,7 +59,6 @@
                                      AutomationProperties.Name="Step 1: Completed"
                                      ToolTip.Tip="Step 1: Completed"/>
                     </Panel>
-                    
                     <!-- Content -->
                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="6">
                         <TextBlock Text="Check PowerShell Modules"
@@ -71,7 +69,6 @@
                                  Opacity="0.7"
                                  TextWrapping="Wrap"/>
                     </StackPanel>
-                    
                     <!-- Action -->
                     <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="24,0,0,0">
                         <Button Command="{Binding CheckModulesCommand}"
@@ -116,7 +113,6 @@
                                      AutomationProperties.Name="Step 2: Completed"
                                      ToolTip.Tip="Step 2: Completed"/>
                     </Panel>
-                    
                     <!-- Content -->
                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="6">
                         <TextBlock Text="Connect to Microsoft Teams"
@@ -127,7 +123,6 @@
                                  Opacity="0.7"
                                  TextWrapping="Wrap"/>
                     </StackPanel>
-                    
                     <!-- Action -->
                     <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="24,0,0,0">
                         <Button Command="{Binding ConnectTeamsCommand}"
@@ -183,7 +178,6 @@
                                      AutomationProperties.Name="Step 3: Completed"
                                      ToolTip.Tip="Step 3: Completed"/>
                     </Panel>
-                    
                     <!-- Content -->
                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="6">
                         <TextBlock Text="Connect to Microsoft Graph"
@@ -194,7 +188,6 @@
                                  Opacity="0.7"
                                  TextWrapping="Wrap"/>
                     </StackPanel>
-                    
                     <!-- Action -->
                     <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="24,0,0,0">
                          <Button Command="{Binding ConnectGraphCommand}"
@@ -253,7 +246,6 @@
                                  FontSize="14"
                                  Opacity="0.7"/>
                     </StackPanel>
-                    
                     <Button Grid.Column="1"
                             Command="{Binding NavigateToPageCommand}"
                             CommandParameter="Variables"

--- a/Views/HolidaysView.axaml
+++ b/Views/HolidaysView.axaml
@@ -10,7 +10,6 @@
              xmlns:converters="clr-namespace:teams_phonemanager.Converters"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <!-- DataContext is set via data binding from MainWindow -->
 
     <UserControl.Resources>
@@ -77,7 +76,7 @@
                                             Command="{Binding OpenCreateHolidayDialogCommand}"
                                             HorizontalAlignment="Left" Classes="IconText">
                                         <StackPanel Orientation="Horizontal">
-                                            <fi:SymbolIcon  Symbol="CalendarAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                            <fi:SymbolIcon  Symbol="CalendarAdd"/>
                                             <TextBlock Text="Create Holiday" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </Button>
@@ -99,7 +98,7 @@
                                             Command="{Binding OpenCheckAutoAttendantDialogCommand}"
                                             HorizontalAlignment="Left" Classes="IconText">
                                         <StackPanel Orientation="Horizontal">
-                                            <fi:SymbolIcon  Symbol="CallCheckmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                            <fi:SymbolIcon  Symbol="CallCheckmark"/>
                                             <TextBlock Text="Check Auto Attendant" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </Button>
@@ -122,7 +121,7 @@
                                                 Command="{Binding OpenAttachHolidayDialogCommand}"
                                                 Margin="0,0,16,0" Classes="IconText">
                                             <StackPanel Orientation="Horizontal">
-                                                <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                <fi:SymbolIcon  Symbol="Link"/>
                                                 <TextBlock Text="Attach to Auto Attendant" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Button>
@@ -167,7 +166,6 @@
                     <StackPanel>
                         <TextBlock Text="Create Holiday"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Holiday Configuration:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
@@ -176,21 +174,20 @@
                                  FontSize="14"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateHolidayDialogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding CreateHolidayCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CalendarAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CalendarAdd"/>
                                     <TextBlock Text="Create Holiday" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -225,34 +222,31 @@
                     <StackPanel>
                         <TextBlock Text="Check Auto Attendant"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Auto Attendant Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding AutoAttendantName}"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will verify that the auto attendant exists and is ready to receive holiday configuration. The value is auto-generated from your variables, but you can modify it if needed."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCheckAutoAttendantDialogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding VerifyAutoAttendantCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Verify &amp; Confirm" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -287,41 +281,37 @@
                     <StackPanel>
                         <TextBlock Text="Attach Holiday to Auto Attendant"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Holiday Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding HolidayName}"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Auto Attendant Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding AutoAttendantName}"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="This will attach the created holiday to the auto attendant, creating a holiday call flow with disconnect action and associating it with the holiday schedule."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseAttachHolidayDialogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button
                                     Command="{Binding AttachHolidayToAutoAttendantCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Link" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Link"/>
                                     <TextBlock Text="Attach Holiday" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -339,9 +329,7 @@
                        Value="0"
                        IsIndeterminate="True"
                        Width="50"
-                       
                        Margin="0,16,0,0"/>
-            
             <!-- Waiting Message -->
             <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
                        FontSize="14"

--- a/Views/M365GroupsView.axaml
+++ b/Views/M365GroupsView.axaml
@@ -11,7 +11,6 @@
              x:Class="teams_phonemanager.Views.M365GroupsView"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <!-- DataContext is set via data binding from MainWindow -->
 
     <UserControl.Resources>
@@ -70,20 +69,17 @@
 
                     <Button Grid.Column="0"
                             Command="{Binding RetrieveM365GroupsCommand}"
-                            
                             Margin="0,0,16,0" Classes="IconText">
                         <StackPanel Orientation="Horizontal">
-                            <fi:SymbolIcon  Symbol="ArrowSync" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                            <fi:SymbolIcon  Symbol="ArrowSync"/>
                             <TextBlock Text="Retrieve Groups" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
-                    
                     <Button Grid.Column="1"
                             Command="{Binding OpenCreateGroupDialogCommand}"
-                            
                             Margin="0,0,16,0" Classes="IconText">
                         <StackPanel Orientation="Horizontal">
-                            <fi:SymbolIcon  Symbol="Add" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                            <fi:SymbolIcon  Symbol="Add"/>
                             <TextBlock Text="Create New Group" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
@@ -169,13 +165,13 @@
                             <Button Command="{Binding NavigateToVariablesPageCommand}"
                                      Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Code" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Code"/>
                                     <TextBlock Text="Go to Variables" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding CheckM365GroupCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Continue" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -210,14 +206,12 @@
                         <StackPanel>
                         <TextBlock Text="Create New M365 Group"
                                  Classes="dialog-title"/>
-                        
                         <TextBlock Text="Group Name:"
                                  FontSize="16"
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,8"/>
                         <TextBox Text="{Binding NewGroupName}"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Description (Optional):"
                                  FontSize="16"
                                  FontWeight="SemiBold"
@@ -228,26 +222,24 @@
                                Height="60"
                                VerticalContentAlignment="Top"
                                Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="The group name is auto-generated from your variables. You can modify it if needed."
                                  FontSize="12"
                                  Opacity="0.7"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseCreateGroupDialogCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding CreateNewGroupCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Add" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Add"/>
                                     <TextBlock Text="Create Group" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>

--- a/Views/VariablesView.axaml
+++ b/Views/VariablesView.axaml
@@ -11,7 +11,6 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <UserControl.Resources>
         <converters:InverseBooleanConverter x:Key="InverseBooleanConverter"/>
         <converters:TimeSpanConverter x:Key="TimeSpanConverter"/>
@@ -62,7 +61,6 @@
 
                 <!-- Tab Control -->
                 <TabControl Grid.Row="1" >
-                    
                     <!-- General Tab -->
                     <TabItem Header="General">
                         <ScrollViewer Margin="8">
@@ -85,28 +83,24 @@
                                              />
                                     <TextBlock Text="Example: Acme Corp" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="0" Grid.Column="1" Margin="4,8,0,8">
                                     <TextBox Watermark="Microsoft Fallback Domain"
                                              Text="{Binding Variables.MsFallbackDomain}"
                                              />
                                     <TextBlock Text="Example: @acme.onmicrosoft.com" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,4,8">
                                     <TextBox Watermark="Customer Code (e.g., acm-luc)"
                                              Text="{Binding Variables.Customer}"
                                              />
                                     <TextBlock Text="Example: acm-luc" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="1" Grid.Column="1" Margin="4,0,0,8">
                                     <TextBox Watermark="Customer Group Name"
                                              Text="{Binding Variables.CustomerGroupName}"
                                              />
                                     <TextBlock Text="Example: immo" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,4,8">
                                     <AutoCompleteBox
                                               ItemsSource="{Binding LanguageOptions}"
@@ -117,7 +111,6 @@
                                               />
                                     <TextBlock Text="Example: de-DE" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="2" Grid.Column="1" Margin="4,0,0,8">
                                     <AutoCompleteBox
                                               ItemsSource="{Binding TimeZoneOptions}"
@@ -128,7 +121,6 @@
                                               />
                                     <TextBlock Text="Example: W. Europe Standard Time" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,4,8">
                                     <AutoCompleteBox
                                               ItemsSource="{Binding UsageLocationOptions}"
@@ -139,7 +131,6 @@
                                               />
                                     <TextBlock Text="Example: CH" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="3" Grid.Column="1" Margin="4,0,0,8">
                                     <Grid>
                                         <TextBox 
@@ -147,7 +138,7 @@
                                                  IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                                  VerticalContentAlignment="Center"
                                                  />
-                                        <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                        <fi:SymbolIcon  Symbol="LockClosed" 
                                                                HorizontalAlignment="Right" 
                                                                VerticalAlignment="Center"
                                                                />
@@ -161,7 +152,6 @@
                     <TabItem Header="Call Queues">
                         <ScrollViewer Margin="8">
                             <StackPanel IsEnabled="{Binding CanProceed}" Spacing="16">
-                                
                                 <!-- Application ID (Read-only) -->
                                 <StackPanel Margin="0,0,0,8">
                                     <Grid>
@@ -170,7 +160,7 @@
                                                  IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                                  VerticalContentAlignment="Center"
                                                  />
-                                        <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                        <fi:SymbolIcon  Symbol="LockClosed" 
                                                                HorizontalAlignment="Right" 
                                                                VerticalAlignment="Center"
                                                                />
@@ -181,7 +171,7 @@
                                 <Button Command="{Binding OpenCallQueueConfigurationDialogCommand}"
                                         HorizontalAlignment="Left" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="Settings" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="Settings"/>
                                         <TextBlock Text="Configure Call Queue Settings" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -218,13 +208,12 @@
                                                  IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                                  VerticalContentAlignment="Center"
                                                  />
-                                        <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                        <fi:SymbolIcon  Symbol="LockClosed" 
                                                                HorizontalAlignment="Right" 
                                                                VerticalAlignment="Center"
                                                                />
                                     </Grid>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="0" Grid.Column="1" Margin="4,8,0,8">
                                     <AutoCompleteBox
                                               ItemsSource="{Binding PhoneNumberTypeOptions}"
@@ -254,7 +243,7 @@
                                     <Button Command="{Binding OpenAutoAttendantConfigurationDialogCommand}"
                                             HorizontalAlignment="Left" Classes="IconText">
                                         <StackPanel Orientation="Horizontal">
-                                            <fi:SymbolIcon  Symbol="Settings" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                            <fi:SymbolIcon  Symbol="Settings"/>
                                             <TextBlock Text="Configure Auto Attendant Settings" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </Button>
@@ -382,12 +371,11 @@
                                     </Grid>
                                     <TextBlock Text="Example: kantonal-2025" FontSize="11" Margin="0,4,0,0" VerticalAlignment="Center"/>
                                 </StackPanel>
-                                
                                 <StackPanel Grid.Row="0" Grid.Column="1" Margin="4,8,0,8">
                                     <Button Command="{Binding OpenHolidaySeriesManagerCommand}"
                                             HorizontalAlignment="Stretch" Classes="IconText">
                                         <StackPanel Orientation="Horizontal">
-                                            <fi:SymbolIcon  Symbol="Calendar" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                            <fi:SymbolIcon  Symbol="Calendar"/>
                                             <TextBlock Text="Manage Holiday Series" VerticalAlignment="Center"/>
                                             <TextBlock Text="{Binding Variables.HolidaySeries.Count, StringFormat=' ({0} holidays)'}"
                                                      Margin="8,0,0,0"
@@ -429,79 +417,73 @@
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="0" Grid.Column="1" Margin="4,8,0,8">
                                     <TextBox 
                                              Text="{Binding Variables.RacqUPN, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="1" Grid.Column="0" Margin="0,0,4,8">
                                     <TextBox 
                                              Text="{Binding Variables.RacqDisplayName, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="1" Grid.Column="1" Margin="4,0,0,8">
                                     <TextBox 
                                              Text="{Binding Variables.CqDisplayName, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="2" Grid.Column="0" Margin="0,0,4,8">
                                     <TextBox 
                                              Text="{Binding Variables.RaaaUPN, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="2" Grid.Column="1" Margin="4,0,0,8">
                                     <TextBox 
                                              Text="{Binding Variables.RaaaDisplayName, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
                                 </Grid>
-                                
                                 <Grid Grid.Row="3" Grid.Column="0" Margin="0,0,4,8">
                                     <TextBox 
                                              Text="{Binding Variables.AaDisplayName, Mode=OneWay}"
                                              IsReadOnly="True" Opacity="0.7" Background="Transparent"
                                              VerticalContentAlignment="Center"
                                              />
-                                    <fi:SymbolIcon  Symbol="LockClosed" Foreground="{DynamicResource TextFillColorPrimaryBrush}" 
+                                    <fi:SymbolIcon  Symbol="LockClosed" 
                                                            HorizontalAlignment="Right" 
                                                            VerticalAlignment="Center"
                                                            />
@@ -521,20 +503,19 @@
                     <Button Command="{Binding LoadVariablesFromFileCommand}"
                              Classes="IconText">
                         <StackPanel Orientation="Horizontal">
-                            <fi:SymbolIcon  Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                            <fi:SymbolIcon  Symbol="FolderOpen"/>
                             <TextBlock Text="Load Variables from File" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                     <Button Command="{Binding SaveVariablesToFileCommand}" Classes="IconText">
                         <StackPanel Orientation="Horizontal">
-                            <fi:SymbolIcon  Symbol="Save" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                            <fi:SymbolIcon  Symbol="Save"/>
                             <TextBlock Text="Save Variables to File" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Button>
                 </StackPanel>
             </Grid>
         </Border>
-        
         <!-- Holiday Time Picker Dialog - Border overlay -->
         <Border IsVisible="{Binding ShowHolidayTimePicker}"
                 Background="#80000000"
@@ -559,15 +540,12 @@
                 <Border Classes="dialog" MinWidth="400" Margin="16">
                     <StackPanel>
                         <TextBlock Text="Select Holiday Time"
-                                 
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Choose a time that aligns with 15-minute boundaries:"
                                  FontSize="14"
                                  TextWrapping="Wrap"
                                  Margin="0,0,0,16"/>
-                        
                         <ComboBox ItemsSource="{Binding TimeOptions}"
                                 SelectedItem="{Binding SelectedHolidayTime, Mode=TwoWay}"
                                 Margin="0,0,0,16">
@@ -577,20 +555,19 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CloseHolidayTimePickerCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding SaveHolidayTimeCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Save Time" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -599,7 +576,6 @@
                 </Border>
             </Grid>
         </Border>
-        
         <!-- Holiday Series Manager Dialog - Border overlay (not Popup to avoid macOS window issues) -->
         <Border IsVisible="{Binding ShowHolidaySeriesManager}"
                 Background="#80000000"
@@ -633,13 +609,10 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
-                        
                         <TextBlock Grid.Row="0"
                                  Text="Manage Holiday Series"
-                                 
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Grid.Row="1"
                                  Text="Add, edit, or remove holiday dates and times. Each holiday will be created with the specified date and time."
                                  FontSize="14"
@@ -651,7 +624,6 @@
                                  FontSize="12"
                                  Opacity="0.7"
                                  Margin="0,0,0,16"/>
-                        
                         <!-- Holiday List - Scrollable with proper constraints -->
                         <ScrollViewer Grid.Row="3"
                                     VerticalScrollBarVisibility="Auto"
@@ -668,7 +640,6 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="Auto"/>
                                                 </Grid.ColumnDefinitions>
-                                                
                                                 <StackPanel Grid.Column="0">
                                                     <TextBlock Text="{Binding DisplayText}"
                                                              FontSize="16"
@@ -678,7 +649,6 @@
                                                              Opacity="0.7"
                                                              IsVisible="{Binding Name, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                                 </StackPanel>
-                                                
                                                 <Button Grid.Column="1"
                                                         Command="{Binding DataContext.EditHolidayCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                         CommandParameter="{Binding}"
@@ -691,7 +661,6 @@
                                                         ToolTip.Tip="Edit Holiday"
                                                         >
                                                     <fi:SymbolIcon  Symbol="Edit"
-                                                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                                                   HorizontalAlignment="Center"
                                                                   VerticalAlignment="Center"/>
                                                 </Button>
@@ -708,7 +677,6 @@
                                                         ToolTip.Tip="Remove Holiday"
                                                         >
                                                     <fi:SymbolIcon  Symbol="Delete"
-                                                                  Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                                                   HorizontalAlignment="Center"
                                                                   VerticalAlignment="Center"/>
                                                 </Button>
@@ -718,35 +686,32 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </ScrollViewer>
-                        
                         <!-- Add Holiday and Delete All Buttons -->
                         <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,0,0,16" Spacing="16">
                             <Button Command="{Binding AddHolidayCommand}"
                                      Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="CalendarAdd" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="CalendarAdd"/>
                                     <TextBlock Text="Add Holiday" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding DeleteAllHolidaysCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Delete" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Delete"/>
                                     <TextBlock Text="Delete All" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                         </StackPanel>
-                        
                         <!-- Use Predefined Sets Button -->
                         <Button Grid.Row="5"
                                 Command="{Binding OpenPredefinedHolidaysWizardCommand}"
                                 HorizontalAlignment="Left"
                                 Margin="0,0,0,16" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon  Symbol="Globe" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon  Symbol="Globe"/>
                                 <TextBlock Text="Use Predefined Sets…" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
-                        
                         <!-- Action Buttons -->
                         <StackPanel Grid.Row="6"
                                   Orientation="Horizontal" 
@@ -755,13 +720,13 @@
                             <Button Command="{Binding CancelHolidaySeriesManagerCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding SaveHolidaySeriesCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Save Series" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -770,7 +735,6 @@
                 </Border>
             </Grid>
         </Border>
-        
         <!-- Edit Holiday Dialog - Border overlay -->
         <Border IsVisible="{Binding ShowEditHolidayDialog}"
                 Background="#80000000"
@@ -795,10 +759,8 @@
                 <Border Classes="dialog" MinWidth="400" Margin="16">
                     <StackPanel>
                         <TextBlock Text="Edit Holiday"
-                                 
                                  FontWeight="SemiBold"
                                  Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Start Date:"
                                  Classes="section-title"
                                  Margin="0,0,0,8"/>
@@ -806,7 +768,6 @@
                                           HorizontalAlignment="Stretch"
                                           VerticalContentAlignment="Center"
                                           Margin="0,0,0,16"/>
-                        
                         <TextBlock Text="Start Time:"
                                  Classes="section-title"
                                  Margin="0,0,0,8"/>
@@ -849,20 +810,19 @@
                             <TextBlock Text="If not set, Teams defaults to next day at 12:00"
                                      Classes="hint"/>
                         </StackPanel>
-                        
                         <StackPanel Orientation="Horizontal" 
                                   HorizontalAlignment="Right"
                                   Spacing="16">
                             <Button Command="{Binding CancelEditHolidayCommand}"
                                     Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
                                     <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
                             <Button Command="{Binding SaveEditHolidayCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Save" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -896,7 +856,6 @@
                 <Border Classes="dialog" MinWidth="500" MaxWidth="700" Margin="16">
                     <StackPanel>
                         <TextBlock Text="Predefined Holiday Sets"
-                                   
                                    FontWeight="SemiBold"
                                    Margin="0,0,0,16"/>
 
@@ -930,7 +889,6 @@
                                             Height="30"
                                             Padding="0">
                                         <fi:SymbolIcon  Symbol="Info"
-                                                      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                                       HorizontalAlignment="Center"
                                                       VerticalAlignment="Center"/>
                                     </Button>
@@ -993,14 +951,14 @@
                         <Button Command="{Binding CancelPredefinedHolidaysWizardCommand}"
                                 Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon Symbol="Dismiss"/>
                                 <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                         <Button Command="{Binding ApplyPredefinedHolidaysCommand}"
                                 IsEnabled="{Binding CanApplyPredefinedSelection}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
-                                <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                <fi:SymbolIcon  Symbol="Checkmark"/>
                                 <TextBlock Text="Add Holidays" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
@@ -1034,7 +992,6 @@
                 <Border Classes="dialog" MinWidth="600" MaxWidth="800" Margin="16">
                     <StackPanel>
                         <TextBlock Text="Aargau Holiday Reference"
-                                   
                                    FontWeight="SemiBold"
                                    Margin="0,0,0,16"/>
 
@@ -1056,7 +1013,7 @@
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                             <Button Command="{Binding CloseAargauInfoCommand}" Classes="IconText">
                                 <StackPanel Orientation="Horizontal">
-                                    <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                    <fi:SymbolIcon  Symbol="Checkmark"/>
                                     <TextBlock Text="Close" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
@@ -1096,14 +1053,11 @@
                     <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0">
                         <StackPanel Spacing="24" Margin="0">
                             <TextBlock Text="Call Queue Configuration"
-                                     
                                      FontWeight="SemiBold"
                                      Margin="0,0,0,8"/>
-                            
                             <!-- Greeting and Music Section -->
                             <StackPanel Spacing="24">
                                 <TextBlock Text="Greeting and Music" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                
                                 <StackPanel Spacing="16">
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Greeting" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1118,7 +1072,6 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowGreetingAudioFile}" Spacing="8">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1132,7 +1085,7 @@
                                                     Classes="IconText"
                                                     VerticalAlignment="Bottom">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                    <fi:SymbolIcon Symbol="FolderOpen"/>
                                                     <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                 </StackPanel>
                                             </Button>
@@ -1141,14 +1094,12 @@
                                                    FontSize="11" 
                                                    Opacity="0.7"/>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowGreetingTextToSpeech}" Spacing="4">
                                         <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                         <TextBox Text="{Binding Variables.CqGreetingTextToSpeechPrompt}"
                                                  Watermark="Enter greeting message"/>
                                     </StackPanel>
                                 </StackPanel>
-                                
                                 <StackPanel Spacing="16">
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Music on Hold" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1163,7 +1114,6 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowMusicOnHoldAudioFile}" Spacing="8">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1177,7 +1127,7 @@
                                                     Classes="IconText"
                                                     VerticalAlignment="Bottom">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                    <fi:SymbolIcon Symbol="FolderOpen"/>
                                                     <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                 </StackPanel>
                                             </Button>
@@ -1188,11 +1138,9 @@
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
-                            
                             <!-- Exception Handling Section -->
                             <StackPanel Spacing="24">
                                 <TextBlock Text="Exception Handling" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                
                                 <!-- Call Overflow -->
                                 <StackPanel Spacing="16">
                                     <TextBlock Text="Call Overflow" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1222,7 +1170,6 @@
                                         <TextBox Text="{Binding Variables.CqOverflowActionTarget}"
                                                  Watermark="Resource Account UPN or M365 Group ID"/>
                                     </StackPanel>
-                                    
                                     <!-- Voicemail Greeting (required for SharedVoicemail) -->
                                     <StackPanel IsVisible="{Binding ShowOverflowVoicemailGreeting}" Spacing="8">
                                         <TextBlock Text="Voicemail Greeting (Required)" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1239,7 +1186,6 @@
                                                 </ComboBox.ItemTemplate>
                                             </ComboBox>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowOverflowVoicemailAudioFile}" Spacing="8">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
                                                 <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1253,7 +1199,7 @@
                                                         Classes="IconText"
                                                         VerticalAlignment="Bottom">
                                                     <StackPanel Orientation="Horizontal">
-                                                        <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                        <fi:SymbolIcon Symbol="FolderOpen"/>
                                                         <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Button>
@@ -1262,7 +1208,6 @@
                                                        FontSize="11" 
                                                        Opacity="0.7"/>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowOverflowVoicemailTextToSpeech}" Spacing="4">
                                             <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                             <TextBox Text="{Binding Variables.CqOverflowActionTextToSpeechPrompt}"
@@ -1270,7 +1215,6 @@
                                         </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
-                                
                                 <!-- Call Timeout -->
                                 <StackPanel Spacing="16">
                                     <TextBlock Text="Call Timeout" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1300,7 +1244,6 @@
                                         <TextBox Text="{Binding Variables.CqTimeoutActionTarget}"
                                                  Watermark="Resource Account UPN or M365 Group ID"/>
                                     </StackPanel>
-                                    
                                     <!-- Voicemail Greeting (required for SharedVoicemail) -->
                                     <StackPanel IsVisible="{Binding ShowTimeoutVoicemailGreeting}" Spacing="8">
                                         <TextBlock Text="Voicemail Greeting (Required)" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1317,7 +1260,6 @@
                                                 </ComboBox.ItemTemplate>
                                             </ComboBox>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowTimeoutVoicemailAudioFile}" Spacing="8">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
                                                 <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1331,7 +1273,7 @@
                                                         Classes="IconText"
                                                         VerticalAlignment="Bottom">
                                                     <StackPanel Orientation="Horizontal">
-                                                        <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                        <fi:SymbolIcon Symbol="FolderOpen"/>
                                                         <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Button>
@@ -1340,7 +1282,6 @@
                                                        FontSize="11" 
                                                        Opacity="0.7"/>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowTimeoutVoicemailTextToSpeech}" Spacing="4">
                                             <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                             <TextBox Text="{Binding Variables.CqTimeoutActionTextToSpeechPrompt}"
@@ -1348,7 +1289,6 @@
                                         </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
-                                
                                 <!-- No Agents Available -->
                                 <StackPanel Spacing="16">
                                     <TextBlock Text="No Agents Available" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1373,7 +1313,6 @@
                                         <TextBox Text="{Binding Variables.CqNoAgentActionTarget}"
                                                  Watermark="Resource Account UPN or M365 Group ID"/>
                                     </StackPanel>
-                                    
                                     <!-- Voicemail Greeting (required for SharedVoicemail) -->
                                     <StackPanel IsVisible="{Binding ShowNoAgentVoicemailGreeting}" Spacing="8">
                                         <TextBlock Text="Voicemail Greeting (Required)" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1390,7 +1329,6 @@
                                                 </ComboBox.ItemTemplate>
                                             </ComboBox>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowNoAgentVoicemailAudioFile}" Spacing="8">
                                             <StackPanel Orientation="Horizontal" Spacing="8">
                                                 <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1404,7 +1342,7 @@
                                                         Classes="IconText"
                                                         VerticalAlignment="Bottom">
                                                     <StackPanel Orientation="Horizontal">
-                                                        <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                        <fi:SymbolIcon Symbol="FolderOpen"/>
                                                         <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                     </StackPanel>
                                                 </Button>
@@ -1413,7 +1351,6 @@
                                                        FontSize="11" 
                                                        Opacity="0.7"/>
                                         </StackPanel>
-                                        
                                         <StackPanel IsVisible="{Binding ShowNoAgentVoicemailTextToSpeech}" Spacing="4">
                                             <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                             <TextBox Text="{Binding Variables.CqNoAgentActionTextToSpeechPrompt}"
@@ -1422,7 +1359,6 @@
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
-                            
                             <!-- Action Buttons -->
                             <StackPanel Orientation="Horizontal" 
                                       HorizontalAlignment="Right"
@@ -1431,13 +1367,13 @@
                                 <Button Command="{Binding CancelCallQueueConfigurationCommand}"
                                         Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon Symbol="Dismiss"/>
                                         <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <Button Command="{Binding SaveCallQueueConfigurationCommand}" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="Checkmark"/>
                                         <TextBlock Text="Save" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -1478,14 +1414,11 @@
                     <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0">
                         <StackPanel Spacing="24" Margin="0">
                             <TextBlock Text="Auto Attendant Configuration"
-                                     
                                      FontWeight="SemiBold"
                                      Margin="0,0,0,8"/>
-                            
                             <!-- Default Call Flow Section -->
                             <StackPanel Spacing="24">
                                 <TextBlock Text="Default Call Flow (Business Hours)" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                
                                 <StackPanel Spacing="16">
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Greeting" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1500,7 +1433,6 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowAaDefaultGreetingAudioFile}" Spacing="8">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1514,7 +1446,7 @@
                                                     Classes="IconText"
                                                     VerticalAlignment="Bottom">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                    <fi:SymbolIcon Symbol="FolderOpen"/>
                                                     <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                 </StackPanel>
                                             </Button>
@@ -1523,7 +1455,6 @@
                                                    FontSize="11" 
                                                    Opacity="0.7"/>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowAaDefaultGreetingTextToSpeech}" Spacing="4">
                                         <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                         <TextBox Text="{Binding Variables.AaDefaultGreetingTextToSpeechPrompt}"
@@ -1550,11 +1481,9 @@
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
-                            
                             <!-- After Hours Call Flow Section -->
                             <StackPanel Spacing="24">
                                 <TextBlock Text="After Hours Call Flow" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                
                                 <StackPanel Spacing="16">
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Greeting" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
@@ -1569,7 +1498,6 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowAaAfterHoursGreetingAudioFile}" Spacing="8">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <StackPanel Spacing="4" HorizontalAlignment="Stretch">
@@ -1583,7 +1511,7 @@
                                                     Classes="IconText"
                                                     VerticalAlignment="Bottom">
                                                 <StackPanel Orientation="Horizontal">
-                                                    <fi:SymbolIcon Symbol="FolderOpen" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                                    <fi:SymbolIcon Symbol="FolderOpen"/>
                                                     <TextBlock Text="Select File" VerticalAlignment="Center"/>
                                                 </StackPanel>
                                             </Button>
@@ -1592,7 +1520,6 @@
                                                    FontSize="11" 
                                                    Opacity="0.7"/>
                                     </StackPanel>
-                                    
                                     <StackPanel IsVisible="{Binding ShowAaAfterHoursGreetingTextToSpeech}" Spacing="4">
                                         <TextBlock Text="Text to Speech Prompt" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                         <TextBox Text="{Binding Variables.AaAfterHoursGreetingTextToSpeechPrompt}"
@@ -1619,7 +1546,6 @@
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
-                            
                             <!-- Action Buttons -->
                             <StackPanel Orientation="Horizontal" 
                                       HorizontalAlignment="Right"
@@ -1628,13 +1554,13 @@
                                 <Button Command="{Binding CancelAutoAttendantConfigurationCommand}"
                                         Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon Symbol="Dismiss" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon Symbol="Dismiss"/>
                                         <TextBlock Text="Cancel" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
                                 <Button Command="{Binding SaveAutoAttendantConfigurationCommand}" Classes="IconText">
                                     <StackPanel Orientation="Horizontal">
-                                        <fi:SymbolIcon  Symbol="Checkmark" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                                        <fi:SymbolIcon  Symbol="Checkmark"/>
                                         <TextBlock Text="Save" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>

--- a/Views/WelcomeView.axaml
+++ b/Views/WelcomeView.axaml
@@ -48,14 +48,14 @@
             <Button Command="{Binding NavigateToGetStartedCommand}"
                     Classes="IconTextCentered" MinWidth="180">
                 <StackPanel Orientation="Horizontal">
-                    <fi:SymbolIcon Symbol="Rocket" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                    <fi:SymbolIcon Symbol="Rocket"/>
                     <TextBlock Text="Get Started"/>
                 </StackPanel>
             </Button>
             <Button Command="{Binding OpenDocumentationCommand}"
                     Classes="IconTextCentered" MinWidth="180">
                 <StackPanel Orientation="Horizontal">
-                    <fi:SymbolIcon Symbol="Open" Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+                    <fi:SymbolIcon Symbol="Open"/>
                     <TextBlock Text="GitHub"/>
                 </StackPanel>
             </Button>

--- a/Views/WizardView.axaml
+++ b/Views/WizardView.axaml
@@ -92,7 +92,7 @@
                                     Width="32" Height="32"
                                     HorizontalAlignment="Left">
                                 <TextBlock Text="{Binding CurrentStep, StringFormat={}{0}}"
-                                         Foreground="White"
+                                         Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
                                          FontWeight="Bold"
                                          FontSize="14"
                                          HorizontalAlignment="Center"
@@ -180,7 +180,6 @@
                                     Orientation="Horizontal" 
                                     HorizontalAlignment="Center"
                                     Spacing="8">
-                            
                             <!-- Execute Step -->
                             <Button Command="{Binding ExecuteCurrentStepCommand}"
                                     Classes="accent"
@@ -199,7 +198,6 @@
                                     <TextBlock Text="Skip" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
-                            
                             <!-- Retry (visible on failure) -->
                             <Button Command="{Binding RetryStepCommand}"
                                     IsVisible="{Binding StepFailed}">
@@ -244,7 +242,7 @@
                         Spacing="12">
                 <ProgressBar IsIndeterminate="True" Width="200"/>
                 <TextBlock Text="{Binding StatusMessage}"
-                         Foreground="White"
+                         Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                          HorizontalAlignment="Center"/>
             </StackPanel>
         </Border>

--- a/teams-phonemanager.Tests/teams-phonemanager.Tests.csproj
+++ b/teams-phonemanager.Tests/teams-phonemanager.Tests.csproj
@@ -9,11 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -32,18 +32,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.4.0" />
+    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="FluentAvaloniaUI" Version="2.5.1" />
     <PackageReference Include="FluentIcons.Avalonia" Version="1.1.223" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.81.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
-    <PackageReference Include="System.IO.Packaging" Version="9.0.4" />
-    <PackageReference Include="System.Management.Automation" Version="7.4.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.0" />
+    <PackageReference Include="System.IO.Packaging" Version="10.0.6" />
+    <PackageReference Include="System.Management.Automation" Version="7.6.0" />
+    <!-- Transitive dependency overrides to resolve known vulnerabilities -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- **Update all NuGet packages** to latest compatible versions (Avalonia 11.3.12, FluentAvaloniaUI 2.5.1, PowerShell SDK 7.6.0, and more)
- **Fix dark mode theming regressions** caused by dependency updates — icon foregrounds, accent button text, and header bar text now use proper contrast colors
- **Remove unused Avalonia.ReactiveUI** dependency (project fully uses CommunityToolkit.Mvvm)
- **Fix PowerShell SDK 7.6.0 breaking change** — `ExecutionPolicy` now gated behind `OperatingSystem.IsWindows()` since it throws `PlatformNotSupportedException` on macOS/Linux

## Changes

### Dependencies (`teams-phonemanager.csproj`)
| Package | Old | New |
|---------|-----|-----|
| Avalonia (all) | 11.2.5 | 11.3.12 |
| FluentAvaloniaUI | 2.4.0 | 2.5.1 |
| CommunityToolkit.Mvvm | 8.2.2 | 8.4.2 |
| Microsoft.Extensions.DI | 8.0.0 | 10.0.6 |
| Microsoft.Identity.Client | 4.81.0 | 4.83.3 |
| Microsoft.PowerShell.SDK | 7.4.1 | 7.6.0 |
| System.Management.Automation | 7.4.1 | 7.6.0 |
| System.IO.Packaging | 9.0.4 | 10.0.6 |
| Avalonia.ReactiveUI | 11.2.5 | **removed** |
| System.Security.Cryptography.Xml | *(transitive)* | 10.0.6 (pinned) |
| Tmds.DBus.Protocol | *(transitive)* | 0.92.0 (pinned) |

### Test Dependencies (`teams-phonemanager.Tests.csproj`)
| Package | Old | New |
|---------|-----|-----|
| coverlet.collector | 6.0.4 | 8.0.1 |
| Microsoft.NET.Test.Sdk | 17.14.1 | 18.4.0 |
| xunit.runner.visualstudio | 3.1.4 | 3.1.5 |

### UI/Theming Fixes
- SymbolIcon foreground: descendant selectors (`ListBoxItem fi|SymbolIcon`, `Button fi|SymbolIcon`, etc.) properly set icon color in dark mode
- Accent buttons (`Button.accent`): white text/icons for contrast on Teams purple
- Header bars (`Border.header`): white text/icons via scoped styles
- Removed ~100 redundant inline `Foreground` attributes from icons across 9 view files
- Removed redundant inline `Background`/`Foreground` from IconOnly buttons
- Added `BorderThickness="0"` and `Background="Transparent"` to `Button.IconOnly` style
- Cleaned up whitespace artifacts from bulk attribute removal

### Code Fixes
- `PowerShellContextService.cs`: `ExecutionPolicy` setting gated behind `OperatingSystem.IsWindows()` for PS SDK 7.6.0 compat
- `Program.cs`: removed `using Avalonia.ReactiveUI` and `.UseReactiveUI()` call

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 104/104 tests pass
- [x] App launches without crash on macOS
- [x] Sidebar icons render white in dark mode
- [x] Header bar title, settings gear, and close icons render white
- [x] Accent buttons (Execute Step, Next) have white text
- [x] IconOnly buttons (Settings, Close) have no visible border