### PR TITLE
feat: typed OperationResult replacing string-sniffed PowerShell output (#60)

### DIFF
--- a/src/TeamsPhoneManager.Application/Interfaces/IPowerShellContextService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IPowerShellContextService.cs
@@ -7,6 +7,15 @@ public interface IPowerShellContextService : IDisposable
 {
     Task<string> ExecuteCommandAsync(string command, CancellationToken cancellationToken = default);
     Task<string> ExecuteCommandAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a command and returns both the flattened text output and the structured error records
+    /// captured from the PowerShell error stream. The text output is byte-identical to what
+    /// <see cref="ExecuteCommandAsync(string, Dictionary{string, string}?, CancellationToken)"/> returns;
+    /// this overload additionally surfaces the raw <c>ErrorRecord</c> details for typed result mapping.
+    /// </summary>
+    Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default);
+
     Task<bool> IsConnectedAsync(string service, CancellationToken cancellationToken = default);
     Task<string> GetConnectionStatusAsync(CancellationToken cancellationToken = default);
 }

--- a/src/TeamsPhoneManager.Application/Results/OperationErrorCategory.cs
+++ b/src/TeamsPhoneManager.Application/Results/OperationErrorCategory.cs
@@ -1,0 +1,27 @@
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Classifies why a PowerShell-backed operation failed. Lives in the Application layer so
+    /// Presentation can branch on typed categories instead of sniffing raw output strings.
+    /// </summary>
+    public enum OperationErrorCategory
+    {
+        /// <summary>No error — the operation succeeded.</summary>
+        None = 0,
+
+        /// <summary>Authentication or session problem (expired session, unauthorized, token/AADSTS failures).</summary>
+        AuthSession,
+
+        /// <summary>The service throttled the request (HTTP 429 / TooManyRequests / rate limiting).</summary>
+        Throttling,
+
+        /// <summary>A referenced object could not be found (404 / not found / does not exist).</summary>
+        NotFound,
+
+        /// <summary>Input or parameter validation failure (invalid argument, parameter binding).</summary>
+        Validation,
+
+        /// <summary>An error occurred but it does not match a more specific category.</summary>
+        Unknown
+    }
+}

--- a/src/TeamsPhoneManager.Application/Results/OperationResult.cs
+++ b/src/TeamsPhoneManager.Application/Results/OperationResult.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Typed result of a PowerShell-backed operation. Replaces string-sniffing of raw output
+    /// (<c>Contains("ERROR:")</c> / <c>Contains("SUCCESS:")</c>) in the Presentation layer.
+    ///
+    /// Carries a success flag, the produced value, a typed <see cref="OperationErrorCategory"/>,
+    /// the structured <see cref="PowerShellErrorInfo"/> records, and a correlation id so downstream
+    /// features (retry, audit log, dashboard) have real context to work with.
+    ///
+    /// The success/error marker parsing that used to live in the ViewModels now lives entirely behind
+    /// this type (produced by <see cref="PowerShellOperationResultMapper"/>); the markers themselves are
+    /// unchanged. <see cref="HasSuccessMarker"/> / <see cref="HasErrorMarker"/> / <see cref="ShouldReportError"/>
+    /// expose the same predicates the ViewModels used, without leaking the literals into Presentation.
+    /// </summary>
+    /// <typeparam name="T">The value type carried on success. For PowerShell commands this is the raw output string.</typeparam>
+    public sealed class OperationResult<T>
+    {
+        private OperationResult(
+            bool isSuccess,
+            T? value,
+            OperationErrorCategory category,
+            string? errorMessage,
+            IReadOnlyList<PowerShellErrorInfo> errors,
+            string correlationId,
+            string rawOutput,
+            bool hasSuccessMarker,
+            bool hasErrorMarker)
+        {
+            IsSuccess = isSuccess;
+            Value = value;
+            Category = category;
+            ErrorMessage = errorMessage;
+            Errors = errors;
+            CorrelationId = correlationId;
+            RawOutput = rawOutput;
+            HasSuccessMarker = hasSuccessMarker;
+            HasErrorMarker = hasErrorMarker;
+        }
+
+        /// <summary>True when the operation completed without any error signal.</summary>
+        public bool IsSuccess { get; }
+
+        /// <summary>The value produced on success (for PowerShell commands, the raw output text). May be present on failure too.</summary>
+        public T? Value { get; }
+
+        /// <summary>Typed error classification. <see cref="OperationErrorCategory.None"/> when <see cref="IsSuccess"/> is true.</summary>
+        public OperationErrorCategory Category { get; }
+
+        /// <summary>Best-effort human-readable error message (from the first error record or ERROR: line). Null on success.</summary>
+        public string? ErrorMessage { get; }
+
+        /// <summary>Structured PowerShell error records (exception type, message, failing command). Empty on success.</summary>
+        public IReadOnlyList<PowerShellErrorInfo> Errors { get; }
+
+        /// <summary>Unique id for correlating this operation across logs / audit trails.</summary>
+        public string CorrelationId { get; }
+
+        /// <summary>The raw PowerShell output text this result was derived from. Equals <see cref="Value"/> for string results.</summary>
+        public string RawOutput { get; }
+
+        /// <summary>True when the raw output contains a <c>SUCCESS</c> marker.</summary>
+        public bool HasSuccessMarker { get; }
+
+        /// <summary>True when the raw output contains an <c>ERROR:</c> marker.</summary>
+        public bool HasErrorMarker { get; }
+
+        /// <summary>
+        /// True when the output should trigger user-facing error handling: an error marker is present and no
+        /// success marker is (mirrors the historic <c>Contains("ERROR:") &amp;&amp; !Contains("SUCCESS")</c> check).
+        /// </summary>
+        public bool ShouldReportError => HasErrorMarker && !HasSuccessMarker;
+
+        /// <summary>
+        /// Low-level constructor used by <see cref="PowerShellOperationResultMapper"/>. Kept internal to the
+        /// Application layer so all construction routes through the mapper (which owns marker/category parsing).
+        /// </summary>
+        internal static OperationResult<T> Create(
+            bool isSuccess,
+            T? value,
+            OperationErrorCategory category,
+            string? errorMessage,
+            IReadOnlyList<PowerShellErrorInfo> errors,
+            string correlationId,
+            string rawOutput,
+            bool hasSuccessMarker,
+            bool hasErrorMarker)
+            => new(isSuccess, value, category, errorMessage, errors, correlationId, rawOutput, hasSuccessMarker, hasErrorMarker);
+    }
+}

--- a/src/TeamsPhoneManager.Application/Results/PowerShellErrorInfo.cs
+++ b/src/TeamsPhoneManager.Application/Results/PowerShellErrorInfo.cs
@@ -1,0 +1,25 @@
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Structured view of a single PowerShell <c>ErrorRecord</c>, surfaced as a framework-free POCO
+    /// so the Presentation layer never has to touch System.Management.Automation types.
+    /// Captures the exception type, message and failing command instead of a single flattened string.
+    /// </summary>
+    public sealed class PowerShellErrorInfo
+    {
+        /// <summary>Full type name of the underlying exception (e.g. <c>System.Management.Automation.RuntimeException</c>).</summary>
+        public string ExceptionType { get; init; } = string.Empty;
+
+        /// <summary>Human-readable exception message.</summary>
+        public string Message { get; init; } = string.Empty;
+
+        /// <summary>The command (or invocation line) that produced the error, when available.</summary>
+        public string FailingCommand { get; init; } = string.Empty;
+
+        /// <summary>PowerShell category info string (e.g. <c>NotSpecified: (:) [], RuntimeException</c>).</summary>
+        public string CategoryInfo { get; init; } = string.Empty;
+
+        /// <summary>Raw <c>ErrorRecord.ToString()</c> for diagnostics / audit logging.</summary>
+        public string RawText { get; init; } = string.Empty;
+    }
+}

--- a/src/TeamsPhoneManager.Application/Results/PowerShellExecutionResult.cs
+++ b/src/TeamsPhoneManager.Application/Results/PowerShellExecutionResult.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Raw outcome of running a PowerShell command through <see cref="Interfaces.IPowerShellContextService"/>:
+    /// the flattened text output plus the structured error records captured from the error stream.
+    /// This is the boundary DTO the Infrastructure layer produces; the Application layer maps it into
+    /// a typed <see cref="OperationResult{T}"/>.
+    /// </summary>
+    public sealed class PowerShellExecutionResult
+    {
+        /// <summary>The combined text output (Information + Warning + result objects + flattened errors), unchanged.</summary>
+        public string Output { get; init; } = string.Empty;
+
+        /// <summary>True when the PowerShell pipeline reported errors (or a host-level exception occurred).</summary>
+        public bool HadErrors { get; init; }
+
+        /// <summary>Structured error records captured from the PowerShell error stream (or a host exception).</summary>
+        public IReadOnlyList<PowerShellErrorInfo> Errors { get; init; } = System.Array.Empty<PowerShellErrorInfo>();
+    }
+}

--- a/src/TeamsPhoneManager.Application/Results/PowerShellOperationResultMapper.cs
+++ b/src/TeamsPhoneManager.Application/Results/PowerShellOperationResultMapper.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Maps raw PowerShell execution output into a typed <see cref="OperationResult{T}"/>.
+    ///
+    /// This is the single place that understands the output markers (<c>SUCCESS</c> / <c>ERROR:</c>) and
+    /// the wording of PowerShell / Graph / Teams error messages. Keeping the marker + category parsing here
+    /// (rather than scattered across ViewModels) is the whole point of issue #60: Presentation consumes the
+    /// typed result, and the markers themselves are never changed.
+    ///
+    /// Pure and side-effect-free, so it is trivially unit-testable.
+    /// </summary>
+    public static class PowerShellOperationResultMapper
+    {
+        private const string SuccessMarker = "SUCCESS";
+        private const string ErrorMarker = "ERROR:";
+
+        // Category keyword tables. Checked in priority order (throttling → auth → not-found → validation).
+        private static readonly string[] ThrottlingKeywords =
+        {
+            "429", "throttl", "toomanyrequests", "too many requests", "rate limit", "retry after", "retry-after"
+        };
+
+        private static readonly string[] AuthSessionKeywords =
+        {
+            "session expired", "session has expired", "please reconnect", "unauthorized", "401",
+            "authentication", "aadsts", "invalidauthenticationtoken", "access token", "token has expired",
+            "token is expired", "not connected", "interactiveauthentication", "forbidden", "403"
+        };
+
+        private static readonly string[] NotFoundKeywords =
+        {
+            "not found", "notfound", "404", "does not exist", "could not be found", "cannot find", "no such"
+        };
+
+        private static readonly string[] ValidationKeywords =
+        {
+            "cannot validate argument", "parameterbindingexception", "parameter binding", "is not valid",
+            "not a valid", "invalid", "validation", "must be", "is required", "missing required"
+        };
+
+        /// <summary>
+        /// Maps a raw execution result into a typed <see cref="OperationResult{T}"/> of the output string.
+        /// </summary>
+        public static OperationResult<string> Map(PowerShellExecutionResult execution, string? correlationId = null)
+        {
+            ArgumentNullException.ThrowIfNull(execution);
+
+            var output = execution.Output ?? string.Empty;
+            var errors = execution.Errors ?? Array.Empty<PowerShellErrorInfo>();
+
+            var hasSuccessMarker = output.Contains(SuccessMarker, StringComparison.Ordinal);
+            var hasErrorMarker = output.Contains(ErrorMarker, StringComparison.Ordinal);
+            var anyError = hasErrorMarker || execution.HadErrors || errors.Count > 0;
+
+            if (!anyError)
+            {
+                return OperationResult<string>.Create(
+                    isSuccess: true,
+                    value: output,
+                    category: OperationErrorCategory.None,
+                    errorMessage: null,
+                    errors: errors,
+                    correlationId: correlationId ?? NewCorrelationId(),
+                    rawOutput: output,
+                    hasSuccessMarker: hasSuccessMarker,
+                    hasErrorMarker: hasErrorMarker);
+            }
+
+            var category = Categorize(output, errors);
+            var errorMessage = BuildErrorMessage(output, errors);
+
+            return OperationResult<string>.Create(
+                isSuccess: false,
+                value: output,
+                category: category,
+                errorMessage: errorMessage,
+                errors: errors,
+                correlationId: correlationId ?? NewCorrelationId(),
+                rawOutput: output,
+                hasSuccessMarker: hasSuccessMarker,
+                hasErrorMarker: hasErrorMarker);
+        }
+
+        /// <summary>
+        /// Builds a typed failure directly, without a PowerShell round-trip (e.g. a pre-flight session-expiry
+        /// check). <paramref name="output"/> is the text the UI historically displayed for this failure.
+        /// </summary>
+        public static OperationResult<string> Failure(
+            OperationErrorCategory category,
+            string errorMessage,
+            string output,
+            string? correlationId = null)
+        {
+            output ??= string.Empty;
+            return OperationResult<string>.Create(
+                isSuccess: false,
+                value: output,
+                category: category,
+                errorMessage: errorMessage,
+                errors: Array.Empty<PowerShellErrorInfo>(),
+                correlationId: correlationId ?? NewCorrelationId(),
+                rawOutput: output,
+                hasSuccessMarker: output.Contains(SuccessMarker, StringComparison.Ordinal),
+                hasErrorMarker: output.Contains(ErrorMarker, StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Classifies error text into a typed category. Considers the combined output plus every structured
+        /// error record (message, category info, raw text). Priority: throttling, auth/session, not-found,
+        /// validation, then unknown.
+        /// </summary>
+        public static OperationErrorCategory Categorize(string output, IReadOnlyList<PowerShellErrorInfo> errors)
+        {
+            var haystack = BuildHaystack(output, errors);
+            if (haystack.Length == 0)
+            {
+                return OperationErrorCategory.Unknown;
+            }
+
+            if (ContainsAny(haystack, ThrottlingKeywords)) return OperationErrorCategory.Throttling;
+            if (ContainsAny(haystack, AuthSessionKeywords)) return OperationErrorCategory.AuthSession;
+            if (ContainsAny(haystack, NotFoundKeywords)) return OperationErrorCategory.NotFound;
+            if (ContainsAny(haystack, ValidationKeywords)) return OperationErrorCategory.Validation;
+
+            return OperationErrorCategory.Unknown;
+        }
+
+        private static string BuildHaystack(string output, IReadOnlyList<PowerShellErrorInfo> errors)
+        {
+            var parts = new List<string>();
+            if (!string.IsNullOrEmpty(output)) parts.Add(output);
+            if (errors != null)
+            {
+                foreach (var e in errors)
+                {
+                    if (!string.IsNullOrEmpty(e.Message)) parts.Add(e.Message);
+                    if (!string.IsNullOrEmpty(e.CategoryInfo)) parts.Add(e.CategoryInfo);
+                    if (!string.IsNullOrEmpty(e.RawText)) parts.Add(e.RawText);
+                    if (!string.IsNullOrEmpty(e.ExceptionType)) parts.Add(e.ExceptionType);
+                }
+            }
+            return string.Join("\n", parts).ToLowerInvariant();
+        }
+
+        private static bool ContainsAny(string haystack, string[] keywords)
+            => keywords.Any(k => haystack.Contains(k, StringComparison.Ordinal));
+
+        private static string BuildErrorMessage(string output, IReadOnlyList<PowerShellErrorInfo> errors)
+        {
+            var firstStructured = errors?.FirstOrDefault(e => !string.IsNullOrWhiteSpace(e.Message));
+            if (firstStructured != null)
+            {
+                return firstStructured.Message;
+            }
+
+            // Fall back to the first ERROR: line in the output.
+            if (!string.IsNullOrEmpty(output))
+            {
+                foreach (var line in output.Split('\n'))
+                {
+                    var idx = line.IndexOf(ErrorMarker, StringComparison.Ordinal);
+                    if (idx >= 0)
+                    {
+                        return line[(idx + ErrorMarker.Length)..].Trim();
+                    }
+                }
+            }
+
+            return "An unspecified PowerShell error occurred.";
+        }
+
+        private static string NewCorrelationId() => Guid.NewGuid().ToString("N");
+    }
+}

--- a/src/TeamsPhoneManager.Infrastructure/PowerShellContextService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/PowerShellContextService.cs
@@ -89,6 +89,14 @@ namespace teams_phonemanager.Services
 
         public async Task<string> ExecuteCommandAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default)
         {
+            // Delegate to the detailed overload and return only the text output, which is byte-identical
+            // to the historic behavior. The structured error records are simply ignored here.
+            var execution = await ExecuteCommandWithDetailsAsync(command, environmentVariables, cancellationToken);
+            return execution.Output;
+        }
+
+        public async Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default)
+        {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(PowerShellContextService));
 
@@ -128,6 +136,7 @@ $ErrorActionPreference = 'Continue'
                     }, cancellationToken);
 
                     var output = new StringBuilder();
+                    var errorInfos = new List<PowerShellErrorInfo>();
 
                     foreach (var item in _powerShell.Streams.Information)
                     {
@@ -146,16 +155,23 @@ $ErrorActionPreference = 'Continue'
                         output.AppendLine(item.ToString());
                     }
 
-                    if (_powerShell.HadErrors)
+                    var hadErrors = _powerShell.HadErrors;
+                    if (hadErrors)
                     {
                         foreach (var error in _powerShell.Streams.Error)
                         {
                             _loggingService.Log($"PowerShell error: {error}", LogLevel.Error);
                             output.AppendLine($"ERROR: {error}");
+                            errorInfos.Add(ToErrorInfo(error));
                         }
                     }
 
-                    return output.ToString();
+                    return new PowerShellExecutionResult
+                    {
+                        Output = output.ToString(),
+                        HadErrors = hadErrors,
+                        Errors = errorInfos
+                    };
                 }
                 finally
                 {
@@ -176,12 +192,51 @@ $ErrorActionPreference = 'Continue'
             catch (Exception ex)
             {
                 _loggingService.Log($"Error executing PowerShell command: {ex.Message}", LogLevel.Error);
-                return $"ERROR: {ex.Message}";
+                return new PowerShellExecutionResult
+                {
+                    Output = $"ERROR: {ex.Message}",
+                    HadErrors = true,
+                    Errors = new List<PowerShellErrorInfo>
+                    {
+                        new()
+                        {
+                            ExceptionType = ex.GetType().FullName ?? ex.GetType().Name,
+                            Message = ex.Message,
+                            FailingCommand = string.Empty,
+                            CategoryInfo = string.Empty,
+                            RawText = ex.ToString()
+                        }
+                    }
+                };
             }
             finally
             {
                 _semaphore.Release();
             }
+        }
+
+        /// <summary>
+        /// Projects a PowerShell <see cref="ErrorRecord"/> into a framework-free <see cref="PowerShellErrorInfo"/>,
+        /// preserving the exception type, message and failing command rather than flattening to a single string.
+        /// </summary>
+        private static PowerShellErrorInfo ToErrorInfo(ErrorRecord error)
+        {
+            var exception = error.Exception;
+            var invocation = error.InvocationInfo;
+            var failingCommand = invocation?.MyCommand?.Name;
+            if (string.IsNullOrEmpty(failingCommand))
+            {
+                failingCommand = invocation?.Line?.Trim();
+            }
+
+            return new PowerShellErrorInfo
+            {
+                ExceptionType = exception?.GetType().FullName ?? exception?.GetType().Name ?? string.Empty,
+                Message = exception?.Message ?? error.ToString(),
+                FailingCommand = failingCommand ?? string.Empty,
+                CategoryInfo = error.CategoryInfo?.ToString() ?? string.Empty,
+                RawText = error.ToString()
+            };
         }
 
         public async Task<bool> IsConnectedAsync(string service, CancellationToken cancellationToken = default)

--- a/src/TeamsPhoneManager.Presentation/ViewModels/AutoAttendantsViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/AutoAttendantsViewModel.cs
@@ -107,10 +107,10 @@ namespace teams_phonemanager.ViewModels
 
                 var command = _powerShellCommandService.GetRetrieveAutoAttendantResourceAccountsCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "RetrieveAutoAttendantResourceAccounts");
-                
-                if (!string.IsNullOrEmpty(result))
+
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    ParseResourceAccountsFromResult(result);
+                    ParseResourceAccountsFromResult(result.Value);
                     StatusMessage = $"Found {ResourceAccounts.Count} resource accounts starting with 'raaa-'";
                     _loggingService.Log($"Retrieved {ResourceAccounts.Count} resource accounts", LogLevel.Info);
                 }
@@ -144,10 +144,10 @@ namespace teams_phonemanager.ViewModels
 
                 var command = _powerShellCommandService.GetRetrieveAutoAttendantsCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "RetrieveAutoAttendants");
-                
-                if (!string.IsNullOrEmpty(result))
+
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    ParseAutoAttendantsFromResult(result);
+                    ParseAutoAttendantsFromResult(result.Value);
                     StatusMessage = $"Found {AutoAttendants.Count} auto attendants containing 'aa-'";
                     _loggingService.Log($"Retrieved {AutoAttendants.Count} auto attendants", LogLevel.Info);
                 }
@@ -340,7 +340,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Resource account '{ResourceAccountUpn}' created successfully";
                     _loggingService.Log($"Resource account {ResourceAccountUpn} created successfully", LogLevel.Info);
@@ -349,8 +349,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error creating resource account: {result}";
-                    _loggingService.Log($"Error creating resource account {ResourceAccountUpn}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error creating resource account: {result.Value}";
+                    _loggingService.Log($"Error creating resource account {ResourceAccountUpn}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -426,7 +426,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Auto attendant '{AutoAttendantName}' created successfully";
                     _loggingService.Log($"Auto attendant {AutoAttendantName} created successfully", LogLevel.Info);
@@ -435,8 +435,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error creating auto attendant: {result}";
-                    _loggingService.Log($"Error creating auto attendant {AutoAttendantName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error creating auto attendant: {result.Value}";
+                    _loggingService.Log($"Error creating auto attendant {AutoAttendantName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -492,7 +492,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Auto attendant '{name}' removed successfully";
                     _loggingService.Log($"Auto attendant {name} removed successfully", LogLevel.Info);
@@ -501,8 +501,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error removing auto attendant: {result}";
-                    _loggingService.Log($"Error removing auto attendant {name}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error removing auto attendant: {result.Value}";
+                    _loggingService.Log($"Error removing auto attendant {name}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -540,15 +540,15 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Schedule '{scheduleName}' removed successfully";
                     _loggingService.Log($"Schedule {scheduleName} removed successfully", LogLevel.Info);
                 }
                 else
                 {
-                    StatusMessage = $"Error removing schedule: {result}";
-                    _loggingService.Log($"Error removing schedule {scheduleName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error removing schedule: {result.Value}";
+                    _loggingService.Log($"Error removing schedule {scheduleName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -587,7 +587,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Resource account '{accountUpn}' removed successfully";
                     _loggingService.Log($"Resource account {accountUpn} removed successfully", LogLevel.Info);
@@ -596,8 +596,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error removing resource account: {result}";
-                    _loggingService.Log($"Error removing resource account {accountUpn}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error removing resource account: {result.Value}";
+                    _loggingService.Log($"Error removing resource account {accountUpn}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)

--- a/src/TeamsPhoneManager.Presentation/ViewModels/BulkOperationsViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/BulkOperationsViewModel.cs
@@ -222,11 +222,11 @@ namespace teams_phonemanager.ViewModels
                 // Execute the entire script as one batch
                 var result = await ExecutePowerShellCommandAsync(bulkScript, "BulkOperations");
 
-                if (!string.IsNullOrEmpty(result))
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    log.AppendLine(result);
+                    log.AppendLine(result.Value);
 
-                    if (result.Contains("ERROR:"))
+                    if (result.HasErrorMarker)
                     {
                         StatusMessage = "Bulk execution completed with errors. Check the log below.";
                         _loggingService.Log("Bulk execution completed with errors", LogLevel.Warning);

--- a/src/TeamsPhoneManager.Presentation/ViewModels/CallQueuesViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/CallQueuesViewModel.cs
@@ -88,9 +88,9 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetRetrieveResourceAccountsCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "RetrieveResourceAccounts");
                 
-                if (!string.IsNullOrEmpty(result))
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    ParseResourceAccountsFromResult(result);
+                    ParseResourceAccountsFromResult(result.Value);
                     StatusMessage = $"Found {ResourceAccounts.Count} resource accounts starting with 'racq-'";
                     _loggingService.Log($"Retrieved {ResourceAccounts.Count} resource accounts", LogLevel.Info);
                 }
@@ -126,9 +126,9 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetRetrieveCallQueuesCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "RetrieveCallQueues");
                 
-                if (!string.IsNullOrEmpty(result))
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    ParseCallQueuesFromResult(result);
+                    ParseCallQueuesFromResult(result.Value);
                     StatusMessage = $"Found {CallQueues.Count} call queues containing 'cq-'";
                     _loggingService.Log($"Retrieved {CallQueues.Count} call queues", LogLevel.Info);
                 }
@@ -221,15 +221,15 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetAssignLicenseCommand(variables.RacqUPN, variables.SkuId);
                 var result = await ExecutePowerShellCommandAsync(command, "AssignLicense");
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"License assigned to resource account '{variables.RacqUPN}' successfully";
                     _loggingService.Log($"License assigned to resource account {variables.RacqUPN}", LogLevel.Info);
                 }
                 else
                 {
-                    StatusMessage = $"Error assigning license: {result}";
-                    _loggingService.Log($"Error assigning license to {variables.RacqUPN}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error assigning license: {result.Value}";
+                    _loggingService.Log($"Error assigning license to {variables.RacqUPN}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -268,10 +268,10 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetM365GroupIdCommand(variables.M365Group);
                 var result = await ExecutePowerShellCommandAsync(command, "GetM365GroupId");
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     // Parse the group ID from the result
-                    var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                    var lines = (result.Value ?? string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries);
                     foreach (var line in lines)
                     {
                         if (line.StartsWith("M365GROUPID:") && line.Length > 12)
@@ -288,8 +288,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error retrieving M365 Group ID: {result}";
-                    _loggingService.Log($"Error retrieving M365 Group ID: {result}", LogLevel.Error);
+                    StatusMessage = $"Error retrieving M365 Group ID: {result.Value}";
+                    _loggingService.Log($"Error retrieving M365 Group ID: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -354,7 +354,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Resource account '{ResourceAccountUpn}' created successfully";
                     _loggingService.Log($"Resource account {ResourceAccountUpn} created successfully", LogLevel.Info);
@@ -362,8 +362,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error creating resource account: {result}";
-                    _loggingService.Log($"Error creating resource account {ResourceAccountUpn}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error creating resource account: {result.Value}";
+                    _loggingService.Log($"Error creating resource account {ResourceAccountUpn}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -419,7 +419,7 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetUpdateResourceAccountUsageLocationCommand(ResourceAccountUpn, variables.UsageLocation);
                 var result = await ExecutePowerShellCommandAsync(command, "UpdateUsageLocation");
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Usage location updated for '{ResourceAccountUpn}' to '{variables.UsageLocation}'";
                     _loggingService.Log($"Usage location updated for {ResourceAccountUpn}", LogLevel.Info);
@@ -427,8 +427,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error updating usage location: {result}";
-                    _loggingService.Log($"Error updating usage location for {ResourceAccountUpn}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error updating usage location: {result.Value}";
+                    _loggingService.Log($"Error updating usage location for {ResourceAccountUpn}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -492,7 +492,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Call queue '{CallQueueName}' created successfully";
                     _loggingService.Log($"Call queue {CallQueueName} created successfully", LogLevel.Info);
@@ -500,8 +500,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error creating call queue: {result}";
-                    _loggingService.Log($"Error creating call queue {CallQueueName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error creating call queue: {result.Value}";
+                    _loggingService.Log($"Error creating call queue {CallQueueName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -558,15 +558,15 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Successfully associated resource account '{ResourceAccountUpn}' with call queue '{CallQueueName}'";
                     _loggingService.Log($"Successfully associated resource account {ResourceAccountUpn} with call queue {CallQueueName}", LogLevel.Info);
                 }
                 else
                 {
-                    StatusMessage = $"Error associating resource account with call queue: {result}";
-                    _loggingService.Log($"Error associating resource account {ResourceAccountUpn} with call queue {CallQueueName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error associating resource account with call queue: {result.Value}";
+                    _loggingService.Log($"Error associating resource account {ResourceAccountUpn} with call queue {CallQueueName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -605,7 +605,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Call queue '{name}' removed successfully";
                     _loggingService.Log($"Call queue {name} removed successfully", LogLevel.Info);
@@ -614,8 +614,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error removing call queue: {result}";
-                    _loggingService.Log($"Error removing call queue {name}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error removing call queue: {result.Value}";
+                    _loggingService.Log($"Error removing call queue {name}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -654,7 +654,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Resource account '{accountUpn}' removed successfully";
                     _loggingService.Log($"Resource account {accountUpn} removed successfully", LogLevel.Info);
@@ -663,8 +663,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error removing resource account: {result}";
-                    _loggingService.Log($"Error removing resource account {accountUpn}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error removing resource account: {result.Value}";
+                    _loggingService.Log($"Error removing resource account {accountUpn}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)

--- a/src/TeamsPhoneManager.Presentation/ViewModels/DocumentationViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/DocumentationViewModel.cs
@@ -87,9 +87,9 @@ namespace teams_phonemanager.ViewModels
                 // 1. Tenant Info
                 StatusMessage = "Exporting tenant info... (1/7)";
                 var tenantResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportTenantInfoCommand(), "ExportTenantInfo");
-                if (!string.IsNullOrEmpty(tenantResult))
+                if (!string.IsNullOrEmpty(tenantResult.Value))
                 {
-                    foreach (var line in tenantResult.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var line in tenantResult.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries))
                     {
                         if (line.StartsWith("DOCDATA_TENANT:") && line.Length > 15)
                         {
@@ -108,38 +108,38 @@ namespace teams_phonemanager.ViewModels
                 // 2. Resource Accounts + Associations
                 StatusMessage = "Exporting resource accounts... (2/7)";
                 var raResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportResourceAccountsCommand(), "ExportResourceAccounts");
-                if (!string.IsNullOrEmpty(raResult))
-                    ParseResourceAccountData(raResult, raList, assocList);
+                if (!string.IsNullOrEmpty(raResult.Value))
+                    ParseResourceAccountData(raResult.Value, raList, assocList);
 
                 // 3. Auto Attendants
                 StatusMessage = "Exporting auto attendants... (3/7)";
                 var aaResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportAutoAttendantsCommand(), "ExportAutoAttendants");
-                if (!string.IsNullOrEmpty(aaResult))
-                    ParseAutoAttendantData(aaResult, aaList, menuOptions, callFlows, chaList, operatorList);
+                if (!string.IsNullOrEmpty(aaResult.Value))
+                    ParseAutoAttendantData(aaResult.Value, aaList, menuOptions, callFlows, chaList, operatorList);
 
                 // 4. Call Queues
                 StatusMessage = "Exporting call queues... (4/7)";
                 var cqResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportCallQueuesCommand(), "ExportCallQueues");
-                if (!string.IsNullOrEmpty(cqResult))
-                    ParseCallQueueData(cqResult, cqList, agentList, overflowList, timeoutList, dlList);
+                if (!string.IsNullOrEmpty(cqResult.Value))
+                    ParseCallQueueData(cqResult.Value, cqList, agentList, overflowList, timeoutList, dlList);
 
                 // 5. Schedules
                 StatusMessage = "Exporting schedules... (5/7)";
                 var schedResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportSchedulesCommand(), "ExportSchedules");
-                if (!string.IsNullOrEmpty(schedResult))
-                    ParseScheduleData(schedResult, schedList, schedDateRanges, schedWeekly);
+                if (!string.IsNullOrEmpty(schedResult.Value))
+                    ParseScheduleData(schedResult.Value, schedList, schedDateRanges, schedWeekly);
 
                 // 6. Phone Numbers
                 StatusMessage = "Exporting phone numbers... (6/7)";
                 var phoneResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportPhoneNumbersCommand(), "ExportPhoneNumbers");
-                if (!string.IsNullOrEmpty(phoneResult))
-                    ParsePhoneData(phoneResult, phoneList);
+                if (!string.IsNullOrEmpty(phoneResult.Value))
+                    ParsePhoneData(phoneResult.Value, phoneList);
 
                 // 7. Voice Users
                 StatusMessage = "Exporting voice users... (7/7)";
                 var userResult = await ExecutePowerShellCommandAsync(_docBuilder.GetExportVoiceUsersCommand(), "ExportVoiceUsers");
-                if (!string.IsNullOrEmpty(userResult))
-                    ParseUserData(userResult, userList);
+                if (!string.IsNullOrEmpty(userResult.Value))
+                    ParseUserData(userResult.Value, userList);
 
                 // Build the comprehensive documentation
                 StatusMessage = "Building documentation...";

--- a/src/TeamsPhoneManager.Presentation/ViewModels/GetStartedViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/GetStartedViewModel.cs
@@ -73,16 +73,17 @@ namespace teams_phonemanager.ViewModels
 
                 var command = _powerShellCommandService.GetCheckModulesCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "CheckModules");
+                var output = result.Value ?? string.Empty;
 
                 // Check for Teams module
-                bool teamsAvailable = result.Contains("MicrosoftTeams module is available") || result.Contains("MicrosoftTeams module installed successfully");
+                bool teamsAvailable = output.Contains("MicrosoftTeams module is available") || output.Contains("MicrosoftTeams module installed successfully");
 
                 // Check for all required Graph modules
-                bool graphAuthAvailable = result.Contains(ConstantsService.PowerShellModules.MicrosoftGraphAuthentication + " module is available");
-                bool graphUsersAvailable = result.Contains(ConstantsService.PowerShellModules.MicrosoftGraphUsers + " module is available");
-                bool graphUsersActionsAvailable = result.Contains(ConstantsService.PowerShellModules.MicrosoftGraphUsersActions + " module is available");
-                bool graphGroupsAvailable = result.Contains(ConstantsService.PowerShellModules.MicrosoftGraphGroups + " module is available");
-                bool graphIdentityAvailable = result.Contains(ConstantsService.PowerShellModules.MicrosoftGraphIdentityDirectoryManagement + " module is available");
+                bool graphAuthAvailable = output.Contains(ConstantsService.PowerShellModules.MicrosoftGraphAuthentication + " module is available");
+                bool graphUsersAvailable = output.Contains(ConstantsService.PowerShellModules.MicrosoftGraphUsers + " module is available");
+                bool graphUsersActionsAvailable = output.Contains(ConstantsService.PowerShellModules.MicrosoftGraphUsersActions + " module is available");
+                bool graphGroupsAvailable = output.Contains(ConstantsService.PowerShellModules.MicrosoftGraphGroups + " module is available");
+                bool graphIdentityAvailable = output.Contains(ConstantsService.PowerShellModules.MicrosoftGraphIdentityDirectoryManagement + " module is available");
 
                 ModulesChecked = teamsAvailable &&
                                 graphAuthAvailable &&
@@ -96,7 +97,7 @@ namespace teams_phonemanager.ViewModels
                 if (ModulesChecked)
                 {
                     _loggingService.Log("PowerShell modules are available", LogLevel.Success);
-                    foreach (var line in result.Split('\n'))
+                    foreach (var line in output.Split('\n'))
                     {
                         if (!string.IsNullOrWhiteSpace(line))
                         {
@@ -138,7 +139,7 @@ namespace teams_phonemanager.ViewModels
 
                 var command = _powerShellCommandService.GetConnectTeamsCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "ConnectTeams");
-                TeamsConnected = result.Contains("SUCCESS:");
+                TeamsConnected = result.HasSuccessMarker;
 
                 string? tenantId = null;
                 string? tenantName = null;
@@ -147,7 +148,7 @@ namespace teams_phonemanager.ViewModels
                 {
                     _loggingService.Log("Connected to Microsoft Teams successfully", LogLevel.Success);
 
-                    foreach (var line in result.Split('\n'))
+                    foreach (var line in (result.Value ?? string.Empty).Split('\n'))
                     {
                         if (line.Contains("Connected to tenant:"))
                         {
@@ -162,7 +163,7 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    _loggingService.Log($"Error connecting to Microsoft Teams: {result}", LogLevel.Error);
+                    _loggingService.Log($"Error connecting to Microsoft Teams: {result.Value}", LogLevel.Error);
                 }
 
                 _sessionManager.UpdateTeamsConnection(TeamsConnected);
@@ -222,7 +223,7 @@ namespace teams_phonemanager.ViewModels
                     { "TEAMS_PM_TOKEN", authResult.AccessToken }
                 };
                 var result = await ExecutePowerShellCommandAsync(command, envVars, "ConnectGraph");
-                GraphConnected = result.Contains("SUCCESS:");
+                GraphConnected = result.HasSuccessMarker;
 
                 string? account = authResult.Account;
 
@@ -232,7 +233,7 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    _loggingService.Log($"Error connecting to Microsoft Graph: {result}", LogLevel.Error);
+                    _loggingService.Log($"Error connecting to Microsoft Graph: {result.Value}", LogLevel.Error);
                 }
 
                 _sessionManager.UpdateGraphConnection(GraphConnected, account);

--- a/src/TeamsPhoneManager.Presentation/ViewModels/HolidaysViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/HolidaysViewModel.cs
@@ -117,7 +117,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Holiday series '{holidayName}' created successfully with {holidayEntries.Count} dates!";
                     _loggingService.Log($"Holiday series {holidayName} created successfully", LogLevel.Info);
@@ -125,8 +125,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    StatusMessage = $"Error creating holiday series: {result}";
-                    _loggingService.Log($"Error creating holiday series {holidayName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error creating holiday series: {result.Value}";
+                    _loggingService.Log($"Error creating holiday series {holidayName}: {result.Value}", LogLevel.Error);
                     IsHolidayCreated = false;
                 }
             }
@@ -182,15 +182,15 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetVerifyAutoAttendantCommand(AutoAttendantName);
                 var result = await ExecutePowerShellCommandAsync(command, "VerifyAutoAttendant");
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Auto attendant '{AutoAttendantName}' verified successfully and is ready for holiday configuration";
                     _loggingService.Log($"Auto attendant {AutoAttendantName} verified successfully", LogLevel.Info);
                 }
                 else
                 {
-                    StatusMessage = $"Error: Auto attendant '{AutoAttendantName}' not found or not accessible: {result}";
-                    _loggingService.Log($"Error verifying auto attendant {AutoAttendantName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error: Auto attendant '{AutoAttendantName}' not found or not accessible: {result.Value}";
+                    _loggingService.Log($"Error verifying auto attendant {AutoAttendantName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -260,15 +260,15 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     StatusMessage = $"Successfully attached holiday '{holidayName}' to auto attendant '{AutoAttendantName}'";
                     _loggingService.Log($"Successfully attached holiday {holidayName} to auto attendant {AutoAttendantName}", LogLevel.Info);
                 }
                 else
                 {
-                    StatusMessage = $"Error attaching holiday to auto attendant: {result}";
-                    _loggingService.Log($"Error attaching holiday {holidayName} to auto attendant {AutoAttendantName}: {result}", LogLevel.Error);
+                    StatusMessage = $"Error attaching holiday to auto attendant: {result.Value}";
+                    _loggingService.Log($"Error attaching holiday {holidayName} to auto attendant {AutoAttendantName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)

--- a/src/TeamsPhoneManager.Presentation/ViewModels/M365GroupsViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/M365GroupsViewModel.cs
@@ -95,10 +95,10 @@ namespace teams_phonemanager.ViewModels
 
                 var command = _powerShellCommandService.GetRetrieveM365GroupsCommand();
                 var result = await ExecutePowerShellCommandAsync(command, "RetrieveM365Groups");
-                
-                if (!string.IsNullOrEmpty(result))
+
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    ParseGroupsFromResult(result);
+                    ParseGroupsFromResult(result.Value);
                     GroupStatus = $"Found {Groups.Count} groups starting with 'ttgrp'";
                     _loggingService.Log($"Retrieved {Groups.Count} M365 groups", LogLevel.Info);
                 }
@@ -157,9 +157,9 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
                 
-                if (!string.IsNullOrEmpty(result))
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    var output = result.Trim();
+                    var output = result.Value.Trim();
                     if (output.Contains("created successfully"))
                     {
                         GroupStatus = $"Group '{NewGroupName}' created successfully";
@@ -221,7 +221,7 @@ namespace teams_phonemanager.ViewModels
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                if (result.HasSuccessMarker)
                 {
                     GroupStatus = $"Group '{SelectedGroup.DisplayName}' removed successfully";
                     _loggingService.Log($"M365 Group {SelectedGroup.DisplayName} removed successfully", LogLevel.Info);
@@ -230,8 +230,8 @@ namespace teams_phonemanager.ViewModels
                 }
                 else
                 {
-                    GroupStatus = $"Error removing group: {result}";
-                    _loggingService.Log($"Error removing M365 Group {SelectedGroup.DisplayName}: {result}", LogLevel.Error);
+                    GroupStatus = $"Error removing group: {result.Value}";
+                    _loggingService.Log($"Error removing M365 Group {SelectedGroup.DisplayName}: {result.Value}", LogLevel.Error);
                 }
             }
             catch (Exception ex)
@@ -273,9 +273,9 @@ namespace teams_phonemanager.ViewModels
                 var command = _powerShellCommandService.GetCreateM365GroupCommand(m365group);
                 var result = await ExecutePowerShellCommandAsync(command, "CheckM365Group");
                 
-                if (!string.IsNullOrEmpty(result))
+                if (!string.IsNullOrEmpty(result.Value))
                 {
-                    var output = result.Trim();
+                    var output = result.Value.Trim();
                     var parts = output.Split(':');
                     if (parts.Length >= 2)
                     {

--- a/src/TeamsPhoneManager.Presentation/ViewModels/VariablesViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/VariablesViewModel.cs
@@ -1031,10 +1031,10 @@ namespace teams_phonemanager.ViewModels
                         var command = _powerShellCommandService.GetImportAudioFileCommand(filePath);
                         var result = await ExecutePowerShellCommandAsync(command, "ImportAudioFile");
                         
-                        if (!string.IsNullOrEmpty(result) && result.Contains("SUCCESS"))
+                        if (result.HasSuccessMarker)
                         {
                             // Parse the audio file ID from the result
-                            var audioFileId = ParseAudioFileIdFromResult(result);
+                            var audioFileId = ParseAudioFileIdFromResult(result.Value ?? string.Empty);
                             if (!string.IsNullOrEmpty(audioFileId))
                             {
                                 var fileName = fileInfo.Name;
@@ -1049,7 +1049,7 @@ namespace teams_phonemanager.ViewModels
                         }
                         else
                         {
-                            await _errorHandlingService.HandleGenericError($"Failed to import audio file:\n{result}", "Import Error");
+                            await _errorHandlingService.HandleGenericError($"Failed to import audio file:\n{result.Value}", "Import Error");
                         }
                     }
                 }

--- a/src/TeamsPhoneManager.Presentation/ViewModels/ViewModelBase.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/ViewModelBase.cs
@@ -65,12 +65,12 @@ namespace teams_phonemanager.ViewModels
             LogMessage = $"{DateTime.Now:HH:mm:ss} - {message}";
         }
 
-        protected async Task<string> ExecutePowerShellCommandAsync(string command, string context = "")
+        protected async Task<OperationResult<string>> ExecutePowerShellCommandAsync(string command, string context = "")
         {
             return await ExecutePowerShellCommandAsync(command, null, context);
         }
 
-        protected async Task<string> ExecutePowerShellCommandAsync(string command, Dictionary<string, string>? environmentVariables, string context = "")
+        protected async Task<OperationResult<string>> ExecutePowerShellCommandAsync(string command, Dictionary<string, string>? environmentVariables, string context = "")
         {
             // Check session expiry before executing commands that require a connection
             if (_sessionManager.IsSessionExpired && _sessionManager.IsSessionValid)
@@ -79,17 +79,21 @@ namespace teams_phonemanager.ViewModels
                 await _errorHandlingService.HandleConnectionError(
                     "Session",
                     "Your session has expired (24h timeout). Please reconnect to Teams and Microsoft Graph.");
-                return "ERROR: Session expired. Please reconnect.";
+                return PowerShellOperationResultMapper.Failure(
+                    OperationErrorCategory.AuthSession,
+                    "Session expired. Please reconnect.",
+                    "ERROR: Session expired. Please reconnect.");
             }
 
             try
             {
-                var result = await _powerShellContextService.ExecuteCommandAsync(command, environmentVariables);
+                var execution = await _powerShellContextService.ExecuteCommandWithDetailsAsync(command, environmentVariables);
+                var result = PowerShellOperationResultMapper.Map(execution);
 
-                // Only treat as error if result contains ERROR: and not SUCCESS
-                if (result.Contains("ERROR:") && !result.Contains("SUCCESS"))
+                // Surface a user-facing error only for a reportable failure (error marker without success marker).
+                if (result.ShouldReportError)
                 {
-                    await _errorHandlingService.HandlePowerShellError(command, result, context);
+                    await _errorHandlingService.HandlePowerShellError(command, result.RawOutput, context);
                 }
 
                 return result;
@@ -97,7 +101,10 @@ namespace teams_phonemanager.ViewModels
             catch (Exception ex)
             {
                 await _errorHandlingService.HandlePowerShellError(command, ex.Message, context);
-                return $"ERROR: {ex.Message}";
+                return PowerShellOperationResultMapper.Failure(
+                    OperationErrorCategory.Unknown,
+                    ex.Message,
+                    $"ERROR: {ex.Message}");
             }
         }
 
@@ -190,7 +197,7 @@ namespace teams_phonemanager.ViewModels
         /// Shows a script preview dialog and executes the command if the user confirms.
         /// Returns the execution result, or null if the user cancelled.
         /// </summary>
-        protected async Task<string?> PreviewAndExecuteAsync(string command, string context = "", Dictionary<string, string>? environmentVariables = null)
+        protected async Task<OperationResult<string>?> PreviewAndExecuteAsync(string command, string context = "", Dictionary<string, string>? environmentVariables = null)
         {
             if (_dialogService != null && !(_sharedStateService?.SkipScriptPreview ?? false))
             {
@@ -209,7 +216,7 @@ namespace teams_phonemanager.ViewModels
         /// Shows a confirmation dialog with script preview for destructive operations.
         /// Returns the execution result, or null if the user cancelled.
         /// </summary>
-        protected async Task<string?> ConfirmAndExecuteAsync(string command, string confirmMessage, string context = "", Dictionary<string, string>? environmentVariables = null)
+        protected async Task<OperationResult<string>?> ConfirmAndExecuteAsync(string command, string confirmMessage, string context = "", Dictionary<string, string>? environmentVariables = null)
         {
             if (_dialogService != null && !(_sharedStateService?.SkipDeleteConfirmation ?? false))
             {

--- a/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
@@ -219,21 +219,23 @@ namespace teams_phonemanager.ViewModels
                 return;
             }
 
-            if (result.Contains("ERROR:"))
+            var output = result.Value ?? string.Empty;
+
+            if (result.HasErrorMarker)
             {
                 step.IsFailed = true;
-                step.Result = result;
+                step.Result = output;
                 StepFailed = true;
-                StepResult = result;
+                StepResult = output;
                 StatusMessage = $"Step {CurrentStep} failed. Review the output and retry or skip.";
-                _loggingService.Log($"Wizard step {CurrentStep} ({step.Title}) failed: {result}", LogLevel.Error);
+                _loggingService.Log($"Wizard step {CurrentStep} ({step.Title}) failed: {output}", LogLevel.Error);
             }
             else
             {
                 step.IsCompleted = true;
-                step.Result = result;
+                step.Result = output;
                 StepCompleted = true;
-                StepResult = string.IsNullOrWhiteSpace(result) ? "Step completed successfully." : result;
+                StepResult = string.IsNullOrWhiteSpace(output) ? "Step completed successfully." : output;
                 StatusMessage = $"Step {CurrentStep} completed: {step.Title}";
                 _loggingService.Log($"Wizard step {CurrentStep} ({step.Title}) completed successfully", LogLevel.Info);
             }

--- a/teams-phonemanager.Tests/PowerShellOperationResultMapperTests.cs
+++ b/teams-phonemanager.Tests/PowerShellOperationResultMapperTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using Xunit;
+using teams_phonemanager.Services;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Covers the mapping layer that turns raw PowerShell output into a typed <see cref="OperationResult{T}"/>:
+    /// success, each error category, and malformed / ambiguous output. This is the seam that replaces
+    /// string-sniffing (<c>Contains("ERROR:")</c>) in the Presentation layer.
+    /// </summary>
+    public class PowerShellOperationResultMapperTests
+    {
+        private static PowerShellExecutionResult Exec(string output, bool hadErrors = false, IReadOnlyList<PowerShellErrorInfo>? errors = null)
+            => new()
+            {
+                Output = output,
+                HadErrors = hadErrors,
+                Errors = errors ?? System.Array.Empty<PowerShellErrorInfo>()
+            };
+
+        [Fact]
+        public void Map_SuccessOutput_IsSuccessAndNoErrorCategory()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("SUCCESS: Connected to Microsoft Teams"));
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.None, result.Category);
+            Assert.True(result.HasSuccessMarker);
+            Assert.False(result.HasErrorMarker);
+            Assert.False(result.ShouldReportError);
+            Assert.Null(result.ErrorMessage);
+            Assert.Empty(result.Errors);
+            Assert.Equal("SUCCESS: Connected to Microsoft Teams", result.Value);
+        }
+
+        [Fact]
+        public void Map_OutputWithoutMarkers_IsTreatedAsSuccess()
+        {
+            // Data-retrieval commands (e.g. GROUP:/DOCDATA rows) carry no SUCCESS/ERROR marker.
+            var result = PowerShellOperationResultMapper.Map(Exec("GROUP: Sales|id-1|sales|desc"));
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.None, result.Category);
+            Assert.False(result.ShouldReportError);
+        }
+
+        [Fact]
+        public void Map_AuthSessionError_IsCategorizedAsAuthSession()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: Session expired. Please reconnect."));
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.AuthSession, result.Category);
+            Assert.True(result.HasErrorMarker);
+            Assert.True(result.ShouldReportError);
+        }
+
+        [Fact]
+        public void Map_UnauthorizedError_IsCategorizedAsAuthSession()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: The request failed: Unauthorized (401)"));
+            Assert.Equal(OperationErrorCategory.AuthSession, result.Category);
+        }
+
+        [Fact]
+        public void Map_ThrottlingError_IsCategorizedAsThrottling()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: Response status code 429 (TooManyRequests)"));
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.Throttling, result.Category);
+        }
+
+        [Fact]
+        public void Map_NotFoundError_IsCategorizedAsNotFound()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: Auto attendant 'aa-x' not found"));
+
+            Assert.Equal(OperationErrorCategory.NotFound, result.Category);
+        }
+
+        [Fact]
+        public void Map_ValidationError_IsCategorizedAsValidation()
+        {
+            var result = PowerShellOperationResultMapper.Map(
+                Exec("ERROR: Cannot validate argument on parameter 'Name'. The argument is not valid."));
+
+            Assert.Equal(OperationErrorCategory.Validation, result.Category);
+        }
+
+        [Fact]
+        public void Map_UnrecognizedError_IsCategorizedAsUnknown()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: Something inexplicable happened"));
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.Unknown, result.Category);
+        }
+
+        [Fact]
+        public void Map_MixedSuccessAndError_DoesNotFlagAsReportable()
+        {
+            // A batch (e.g. bulk operations) can emit both SUCCESS and ERROR lines.
+            var result = PowerShellOperationResultMapper.Map(
+                Exec("SUCCESS: Created call queue\nERROR: Failed to assign license: 429"));
+
+            Assert.True(result.HasSuccessMarker);
+            Assert.True(result.HasErrorMarker);
+            // Mirrors the historic ViewModelBase predicate: ERROR: && !SUCCESS.
+            Assert.False(result.ShouldReportError);
+            // A category is still assigned because an error signal was present.
+            Assert.Equal(OperationErrorCategory.Throttling, result.Category);
+        }
+
+        [Fact]
+        public void Map_StructuredErrorRecords_AreSurfacedAndCategorized()
+        {
+            var errors = new List<PowerShellErrorInfo>
+            {
+                new()
+                {
+                    ExceptionType = "System.Management.Automation.RuntimeException",
+                    Message = "Resource account not found",
+                    FailingCommand = "Get-CsOnlineApplicationInstance",
+                    CategoryInfo = "ObjectNotFound: (:) [], RuntimeException",
+                    RawText = "Get-CsOnlineApplicationInstance : Resource account not found"
+                }
+            };
+            var result = PowerShellOperationResultMapper.Map(Exec("ERROR: failed", hadErrors: true, errors: errors));
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.NotFound, result.Category);
+            Assert.Single(result.Errors);
+            Assert.Equal("Get-CsOnlineApplicationInstance", result.Errors[0].FailingCommand);
+            Assert.Equal("Resource account not found", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void Map_HadErrorsWithoutMarker_IsStillAFailure()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec(string.Empty, hadErrors: true));
+
+            Assert.False(result.IsSuccess);
+            Assert.NotEqual(OperationErrorCategory.None, result.Category);
+        }
+
+        [Fact]
+        public void Map_MalformedEmptyOutput_IsSuccessWithNoErrors()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec(string.Empty));
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.None, result.Category);
+            Assert.Equal(string.Empty, result.Value);
+        }
+
+        [Fact]
+        public void Map_AssignsCorrelationId()
+        {
+            var a = PowerShellOperationResultMapper.Map(Exec("SUCCESS: ok"));
+            var b = PowerShellOperationResultMapper.Map(Exec("SUCCESS: ok"));
+
+            Assert.False(string.IsNullOrWhiteSpace(a.CorrelationId));
+            Assert.NotEqual(a.CorrelationId, b.CorrelationId);
+        }
+
+        [Fact]
+        public void Map_HonorsSuppliedCorrelationId()
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec("SUCCESS: ok"), correlationId: "fixed-id");
+            Assert.Equal("fixed-id", result.CorrelationId);
+        }
+
+        [Fact]
+        public void Failure_BuildsTypedFailureWithoutRoundTrip()
+        {
+            var result = PowerShellOperationResultMapper.Failure(
+                OperationErrorCategory.AuthSession,
+                "Session expired. Please reconnect.",
+                "ERROR: Session expired. Please reconnect.");
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(OperationErrorCategory.AuthSession, result.Category);
+            Assert.True(result.HasErrorMarker);
+            Assert.True(result.ShouldReportError);
+            Assert.Equal("Session expired. Please reconnect.", result.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("ERROR: throttled, retry after 30s", OperationErrorCategory.Throttling)]
+        [InlineData("ERROR: AADSTS700082 the token has expired", OperationErrorCategory.AuthSession)]
+        [InlineData("ERROR: The group does not exist", OperationErrorCategory.NotFound)]
+        [InlineData("ERROR: Parameter binding failed: value is not valid", OperationErrorCategory.Validation)]
+        public void Categorize_PrioritizesCorrectly(string output, OperationErrorCategory expected)
+        {
+            var result = PowerShellOperationResultMapper.Map(Exec(output));
+            Assert.Equal(expected, result.Category);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #60.

Introduces a typed `OperationResult<T>` in the Application layer; all ViewModels now consume typed results instead of sniffing PowerShell output strings.

### Design
- `OperationResult<T>` — success flag, value, error category, structured errors, correlation ID (`src/TeamsPhoneManager.Application/Results/`)
- `OperationErrorCategory` — AuthSession, Throttling, NotFound, Validation, Unknown (+ None)
- `PowerShellErrorInfo` — structured capture of each ErrorRecord (exception type, message, failing command)
- `PowerShellOperationResultMapper` — pure, unit-tested single home of the `SUCCESS`/`ERROR:` marker literals and keyword categorization
- Infrastructure adds `ExecuteCommandWithDetailsAsync`; the existing `ExecuteCommandAsync` delegates to it — output byte-identical
- `ViewModelBase` + 9 ViewModels migrated; error-dialog trigger `ShouldReportError` is the exact historic predicate (`ERROR: && !SUCCESS`)

### Behavior preservation
- No ScriptBuilder file touched; generated PowerShell byte-identical (snapshot tests unchanged)
- MSAL/Graph auth untouched
- Dependency Rule holds: Application references only Domain

### Verification (independent pass)
- `dotnet build` — 0 warnings, 0 errors (warnings-as-errors on)
- `dotnet test` — **147/147 passed** (18 new mapper tests)
- Grep confirms zero `Contains("ERROR:")` / `Contains("SUCCESS")` left in Presentation

### Scoping note
Structured data-row deserialization (`GROUP:`, `DOCDATA_*`, `RESOURCEACCOUNT:` …) still parses `result.Value` in Presentation — that's record extraction, not error sniffing, and is a clean separable follow-up (typed row-parsers can hang off the same seam).