### PR TITLE
feat: fully async PowerShell execution with progress and cancellation (#61)

### DIFF
--- a/src/TeamsPhoneManager.Application/Interfaces/IPowerShellContextService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IPowerShellContextService.cs
@@ -13,8 +13,13 @@ public interface IPowerShellContextService : IDisposable
     /// captured from the PowerShell error stream. The text output is byte-identical to what
     /// <see cref="ExecuteCommandAsync(string, Dictionary{string, string}?, CancellationToken)"/> returns;
     /// this overload additionally surfaces the raw <c>ErrorRecord</c> details for typed result mapping.
+    ///
+    /// When <paramref name="progress"/> is supplied, native PowerShell progress records (emitted by cmdlets
+    /// via <c>Write-Progress</c>) are forwarded to it while the command runs. Cancelling
+    /// <paramref name="cancellationToken"/> stops the running pipeline cooperatively and leaves the
+    /// persistent runspace open and reusable for the next command.
     /// </summary>
-    Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default);
+    Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, IProgress<PowerShellProgress>? progress = null, CancellationToken cancellationToken = default);
 
     Task<bool> IsConnectedAsync(string service, CancellationToken cancellationToken = default);
     Task<string> GetConnectionStatusAsync(CancellationToken cancellationToken = default);

--- a/src/TeamsPhoneManager.Application/Progress/PowerShellProgress.cs
+++ b/src/TeamsPhoneManager.Application/Progress/PowerShellProgress.cs
@@ -1,0 +1,44 @@
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Framework-free snapshot of PowerShell progress, forwarded from the Infrastructure layer to the
+    /// Presentation layer via <see cref="System.IProgress{T}"/>. Produced by observing the PowerShell
+    /// <c>Progress</c> stream (native <c>Write-Progress</c> records emitted by cmdlets) — it never changes
+    /// the generated script text.
+    ///
+    /// When <see cref="PercentComplete"/> is negative the operation is indeterminate (the cmdlet did not
+    /// report a percentage); otherwise it is a determinate value in the 0..100 range.
+    /// </summary>
+    public sealed record PowerShellProgress
+    {
+        /// <summary>High-level activity description (PowerShell <c>ProgressRecord.Activity</c>).</summary>
+        public string Activity { get; init; } = string.Empty;
+
+        /// <summary>Current status line (PowerShell <c>ProgressRecord.StatusDescription</c>).</summary>
+        public string StatusDescription { get; init; } = string.Empty;
+
+        /// <summary>The specific sub-operation in progress (PowerShell <c>ProgressRecord.CurrentOperation</c>).</summary>
+        public string CurrentOperation { get; init; } = string.Empty;
+
+        /// <summary>0..100 for determinate progress, or a negative value when indeterminate.</summary>
+        public int PercentComplete { get; init; } = -1;
+
+        /// <summary>True when no meaningful percentage is available and the UI should show an indeterminate indicator.</summary>
+        public bool IsIndeterminate => PercentComplete < 0;
+
+        /// <summary>
+        /// A single human-readable line combining the non-empty parts, for direct display in a busy overlay.
+        /// </summary>
+        public string DisplayText
+        {
+            get
+            {
+                var parts = new System.Collections.Generic.List<string>(3);
+                if (!string.IsNullOrWhiteSpace(Activity)) parts.Add(Activity.Trim());
+                if (!string.IsNullOrWhiteSpace(StatusDescription)) parts.Add(StatusDescription.Trim());
+                if (!string.IsNullOrWhiteSpace(CurrentOperation)) parts.Add(CurrentOperation.Trim());
+                return string.Join(" — ", parts);
+            }
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Application/Results/OperationErrorCategory.cs
+++ b/src/TeamsPhoneManager.Application/Results/OperationErrorCategory.cs
@@ -22,6 +22,9 @@ namespace teams_phonemanager.Services
         Validation,
 
         /// <summary>An error occurred but it does not match a more specific category.</summary>
-        Unknown
+        Unknown,
+
+        /// <summary>The operation was cancelled cooperatively by the user before it completed.</summary>
+        Cancelled
     }
 }

--- a/src/TeamsPhoneManager.Infrastructure/PowerShellContextService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/PowerShellContextService.cs
@@ -91,11 +91,11 @@ namespace teams_phonemanager.Services
         {
             // Delegate to the detailed overload and return only the text output, which is byte-identical
             // to the historic behavior. The structured error records are simply ignored here.
-            var execution = await ExecuteCommandWithDetailsAsync(command, environmentVariables, cancellationToken);
+            var execution = await ExecuteCommandWithDetailsAsync(command, environmentVariables, null, cancellationToken);
             return execution.Output;
         }
 
-        public async Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, CancellationToken cancellationToken = default)
+        public async Task<PowerShellExecutionResult> ExecuteCommandWithDetailsAsync(string command, Dictionary<string, string>? environmentVariables, IProgress<PowerShellProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(PowerShellContextService));
@@ -129,11 +129,80 @@ $ErrorActionPreference = 'Continue'
 
                     _powerShell.AddScript(fullCommand);
 
-                    var result = await Task.Run(() =>
+                    // Forward native PowerShell progress records (Write-Progress from cmdlets) to the caller.
+                    // This only OBSERVES the existing Progress stream; it never alters the script text.
+                    void OnProgressAdded(object? sender, DataAddedEventArgs e)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        return _powerShell.Invoke();
-                    }, cancellationToken);
+                        try
+                        {
+                            var record = _powerShell.Streams.Progress[e.Index];
+                            progress?.Report(new PowerShellProgress
+                            {
+                                Activity = record.Activity ?? string.Empty,
+                                StatusDescription = record.StatusDescription ?? string.Empty,
+                                CurrentOperation = record.CurrentOperation ?? string.Empty,
+                                // A Completed record means the activity is done; treat it as 100%.
+                                PercentComplete = record.RecordType == ProgressRecordType.Completed
+                                    ? 100
+                                    : record.PercentComplete
+                            });
+                        }
+                        catch
+                        {
+                            // Progress reporting is best-effort and must never break command execution.
+                        }
+                    }
+
+                    if (progress != null)
+                    {
+                        _powerShell.Streams.Progress.DataAdded += OnProgressAdded;
+                    }
+
+                    System.Collections.ObjectModel.Collection<PSObject> result;
+                    try
+                    {
+                        result = await Task.Run(() =>
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            // Wire cooperative cancellation to the running pipeline. Stop() interrupts an
+                            // in-flight Invoke() (which then throws PipelineStoppedException) but leaves the
+                            // runspace in the Opened state, so the very next command reuses it unchanged.
+                            using var cancelRegistration = cancellationToken.Register(static state =>
+                            {
+                                try { ((PowerShell)state!).Stop(); }
+                                catch { /* pipeline may have already finished */ }
+                            }, _powerShell);
+
+                            try
+                            {
+                                var invoked = _powerShell.Invoke();
+
+                                // Depending on the host, Stop() either makes Invoke() throw
+                                // PipelineStoppedException or return an (empty) collection with the
+                                // invocation state set to Stopped. Handle the non-throwing case here.
+                                if (cancellationToken.IsCancellationRequested ||
+                                    _powerShell.InvocationStateInfo.State == PSInvocationState.Stopped)
+                                {
+                                    throw new OperationCanceledException(cancellationToken);
+                                }
+
+                                return invoked;
+                            }
+                            catch (PipelineStoppedException)
+                            {
+                                // The pipeline was stopped by our cancellation registration above.
+                                throw new OperationCanceledException(cancellationToken);
+                            }
+                        }, cancellationToken);
+                    }
+                    finally
+                    {
+                        if (progress != null)
+                        {
+                            _powerShell.Streams.Progress.DataAdded -= OnProgressAdded;
+                        }
+                    }
 
                     var output = new StringBuilder();
                     var errorInfos = new List<PowerShellErrorInfo>();
@@ -188,6 +257,14 @@ $ErrorActionPreference = 'Continue'
                         }
                     }
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                // Cooperative cancellation is not a failure: surface it to the caller (which shows a
+                // "cancelled" status rather than an error dialog). Environment variables were already
+                // cleared by the inner finally, and the semaphore is released by the outer finally.
+                _loggingService.Log("PowerShell command cancelled by user", LogLevel.Info);
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/TeamsPhoneManager.Presentation/ViewModels/ViewModelBase.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/ViewModelBase.cs
@@ -1,5 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System;
 using System.ComponentModel;
+using System.Threading;
 using teams_phonemanager.Services;
 using teams_phonemanager.Services.Interfaces;
 
@@ -29,12 +32,64 @@ namespace teams_phonemanager.ViewModels
         [ObservableProperty]
         private string _logMessage = string.Empty;
 
+        /// <summary>True while a cancellable PowerShell operation is running; drives the Cancel affordance.</summary>
+        [ObservableProperty]
+        private bool _isCancellable;
+
+        /// <summary>Determinate progress value (0..100). Only meaningful when <see cref="IsProgressIndeterminate"/> is false.</summary>
+        [ObservableProperty]
+        private double _progressValue;
+
+        /// <summary>True when the running operation reports no percentage and the UI should show an indeterminate bar.</summary>
+        [ObservableProperty]
+        private bool _isProgressIndeterminate = true;
+
+        /// <summary>Human-readable progress line surfaced from native PowerShell <c>Write-Progress</c> records.</summary>
+        [ObservableProperty]
+        private string _progressText = string.Empty;
+
+        /// <summary>
+        /// Token source for the operation currently in flight. Cancelling it stops the PowerShell pipeline
+        /// cooperatively (the runspace stays reusable). Null when no operation is running.
+        /// </summary>
+        private CancellationTokenSource? _operationCts;
+
         partial void OnIsBusyChanged(bool value)
         {
             if (!value)
             {
                 WaitingMessage = string.Empty;
             }
+        }
+
+        /// <summary>
+        /// Requests cancellation of the operation currently in flight. Safe to call when nothing is running.
+        /// Cancellation is cooperative: the PowerShell pipeline is stopped and the persistent runspace is
+        /// left open for the next command.
+        /// </summary>
+        [RelayCommand]
+        protected void CancelOperation()
+        {
+            if (_operationCts is { IsCancellationRequested: false })
+            {
+                _loggingService.Log("Cancellation requested by user", LogLevel.Info);
+                StatusMessage = "Cancelling…";
+                _operationCts.Cancel();
+            }
+        }
+
+        private void ResetProgress()
+        {
+            ProgressValue = 0;
+            IsProgressIndeterminate = true;
+            ProgressText = string.Empty;
+        }
+
+        private void OnPowerShellProgress(PowerShellProgress update)
+        {
+            IsProgressIndeterminate = update.IsIndeterminate;
+            ProgressValue = update.IsIndeterminate ? 0 : update.PercentComplete;
+            ProgressText = update.DisplayText;
         }
 
         protected ViewModelBase(
@@ -85,9 +140,18 @@ namespace teams_phonemanager.ViewModels
                     "ERROR: Session expired. Please reconnect.");
             }
 
+            using var cts = new CancellationTokenSource();
+            _operationCts = cts;
+            IsCancellable = true;
+            ResetProgress();
+
+            // Progress<T> marshals callbacks back onto the captured (UI) SynchronizationContext, so the
+            // observable progress properties are always updated on the UI thread.
+            var progress = new Progress<PowerShellProgress>(OnPowerShellProgress);
+
             try
             {
-                var execution = await _powerShellContextService.ExecuteCommandWithDetailsAsync(command, environmentVariables);
+                var execution = await _powerShellContextService.ExecuteCommandWithDetailsAsync(command, environmentVariables, progress, cts.Token);
                 var result = PowerShellOperationResultMapper.Map(execution);
 
                 // Surface a user-facing error only for a reportable failure (error marker without success marker).
@@ -98,6 +162,17 @@ namespace teams_phonemanager.ViewModels
 
                 return result;
             }
+            catch (OperationCanceledException)
+            {
+                // User cancelled: this is not an error, so we deliberately do NOT raise the error dialog.
+                // The runspace remains reusable, so the next operation runs normally.
+                _loggingService.Log($"Operation cancelled: {context}", LogLevel.Warning);
+                StatusMessage = "Operation cancelled.";
+                return PowerShellOperationResultMapper.Failure(
+                    OperationErrorCategory.Cancelled,
+                    "Operation cancelled by user.",
+                    "ERROR: Operation cancelled by user.");
+            }
             catch (Exception ex)
             {
                 await _errorHandlingService.HandlePowerShellError(command, ex.Message, context);
@@ -105,6 +180,12 @@ namespace teams_phonemanager.ViewModels
                     OperationErrorCategory.Unknown,
                     ex.Message,
                     $"ERROR: {ex.Message}");
+            }
+            finally
+            {
+                _operationCts = null;
+                IsCancellable = false;
+                ResetProgress();
             }
         }
 

--- a/src/TeamsPhoneManager.Presentation/Views/AutoAttendantsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/AutoAttendantsView.axaml
@@ -1059,17 +1059,31 @@
             <!-- Progress Indicator -->
             <Grid Opacity="0.8"
                   IsVisible="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <ProgressBar
-                           Value="0"
-                           IsIndeterminate="True"
-                           Width="50"
-                           Margin="0,16,0,0"/>
-                <!-- Waiting Message -->
-                <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
-                           FontSize="14"
-                           TextWrapping="Wrap"
-                           Margin="0,8,0,0"
-                           TextAlignment="Center"/>
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12" MaxWidth="360">
+                    <ProgressBar
+                               Minimum="0"
+                               Maximum="100"
+                               Value="{Binding ProgressValue}"
+                               IsIndeterminate="{Binding IsProgressIndeterminate}"
+                               Width="200"/>
+                    <!-- Waiting Message -->
+                    <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
+                               FontSize="14"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"/>
+                    <!-- Native PowerShell progress detail -->
+                    <TextBlock Text="{Binding ProgressText}"
+                               IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"/>
+                    <!-- Cancel affordance -->
+                    <Button Content="Cancel"
+                            Command="{Binding CancelOperationCommand}"
+                            IsVisible="{Binding IsCancellable}"
+                            HorizontalAlignment="Center"/>
+                </StackPanel>
             </Grid>
     </Grid>
 </UserControl> 

--- a/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
@@ -88,9 +88,25 @@
                              Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                              IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     <!-- Progress -->
-                    <ProgressBar IsIndeterminate="True"
+                    <ProgressBar Minimum="0"
+                                 Maximum="100"
+                                 Value="{Binding ProgressValue}"
+                                 IsIndeterminate="{Binding IsProgressIndeterminate}"
                                  IsVisible="{Binding IsExecuting}"
                                  Margin="0,6,0,0"/>
+                    <!-- Native PowerShell progress detail -->
+                    <TextBlock Text="{Binding ProgressText}"
+                               IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               Margin="0,4,0,0"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"/>
+                    <!-- Cancel affordance -->
+                    <Button Content="Cancel"
+                            Command="{Binding CancelOperationCommand}"
+                            IsVisible="{Binding IsCancellable}"
+                            Margin="0,8,0,0"
+                            HorizontalAlignment="Left"/>
                 </StackPanel>
 
                 <!-- Content Tabs -->

--- a/src/TeamsPhoneManager.Presentation/Views/CallQueuesView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/CallQueuesView.axaml
@@ -645,18 +645,31 @@
                   ZIndex="2000"
                   Background="#40000000"
                   IsVisible="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12" MaxWidth="360">
                     <ProgressBar
                                AutomationProperties.Name="Operation Progress"
-                               Value="0"
-                               IsIndeterminate="True"
-                               Width="50"
-                               Margin="0,0,0,16"/>
+                               Minimum="0"
+                               Maximum="100"
+                               Value="{Binding ProgressValue}"
+                               IsIndeterminate="{Binding IsProgressIndeterminate}"
+                               Width="200"/>
                     <!-- Waiting Message -->
                     <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
                                FontSize="14"
                                TextWrapping="Wrap"
                                TextAlignment="Center"/>
+                    <!-- Native PowerShell progress detail -->
+                    <TextBlock Text="{Binding ProgressText}"
+                               IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"/>
+                    <!-- Cancel affordance -->
+                    <Button Content="Cancel"
+                            Command="{Binding CancelOperationCommand}"
+                            IsVisible="{Binding IsCancellable}"
+                            HorizontalAlignment="Center"/>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/src/TeamsPhoneManager.Presentation/Views/HolidaysView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/HolidaysView.axaml
@@ -328,20 +328,34 @@
         </Border>
 
         <!-- Progress Indicator -->
-        <Grid 
+        <Grid
               Opacity="0.8"
               IsVisible="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12" MaxWidth="360">
                 <ProgressBar
-                       Value="0"
-                       IsIndeterminate="True"
-                       Width="50"
-                       Margin="0,16,0,0"/>
-            <!-- Waiting Message -->
-            <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
-                       FontSize="14"
-                       TextWrapping="Wrap"
-                       Margin="0,8,0,0"
-                       TextAlignment="Center"/>
+                       Minimum="0"
+                       Maximum="100"
+                       Value="{Binding ProgressValue}"
+                       IsIndeterminate="{Binding IsProgressIndeterminate}"
+                       Width="200"/>
+                <!-- Waiting Message -->
+                <TextBlock Text="{Binding WaitingMessage, TargetNullValue=''}"
+                           FontSize="14"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"/>
+                <!-- Native PowerShell progress detail -->
+                <TextBlock Text="{Binding ProgressText}"
+                           IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           FontSize="12"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"/>
+                <!-- Cancel affordance -->
+                <Button Content="Cancel"
+                        Command="{Binding CancelOperationCommand}"
+                        IsVisible="{Binding IsCancellable}"
+                        HorizontalAlignment="Center"/>
+            </StackPanel>
         </Grid>
     </Grid>
 </UserControl> 

--- a/src/TeamsPhoneManager.Presentation/Views/M365GroupsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/M365GroupsView.axaml
@@ -258,13 +258,28 @@
             </Border>
 
             <!-- Progress Indicator -->
-            <Grid 
+            <Grid
                   Opacity="0.8"
                   IsVisible="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <ProgressBar Value="0"
-                           IsIndeterminate="True"
-                           Width="50"
-                           />
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12" MaxWidth="360">
+                    <ProgressBar Minimum="0"
+                               Maximum="100"
+                               Value="{Binding ProgressValue}"
+                               IsIndeterminate="{Binding IsProgressIndeterminate}"
+                               Width="200"/>
+                    <!-- Native PowerShell progress detail -->
+                    <TextBlock Text="{Binding ProgressText}"
+                               IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                               FontSize="12"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"/>
+                    <!-- Cancel affordance -->
+                    <Button Content="Cancel"
+                            Command="{Binding CancelOperationCommand}"
+                            IsVisible="{Binding IsCancellable}"
+                            HorizontalAlignment="Center"/>
+                </StackPanel>
             </Grid>
         </Grid>
     </Border>

--- a/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
@@ -236,13 +236,33 @@
         <Border IsVisible="{Binding IsBusy}"
                 Background="#80000000"
                 CornerRadius="8">
-            <StackPanel HorizontalAlignment="Center" 
+            <StackPanel HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Spacing="12">
-                <ProgressBar IsIndeterminate="True" Width="200"/>
+                        Spacing="12"
+                        MaxWidth="360">
+                <ProgressBar Minimum="0"
+                             Maximum="100"
+                             Value="{Binding ProgressValue}"
+                             IsIndeterminate="{Binding IsProgressIndeterminate}"
+                             Width="200"/>
                 <TextBlock Text="{Binding StatusMessage}"
                          Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                         TextWrapping="Wrap"
+                         TextAlignment="Center"
                          HorizontalAlignment="Center"/>
+                <!-- Native PowerShell progress detail -->
+                <TextBlock Text="{Binding ProgressText}"
+                           IsVisible="{Binding ProgressText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                           FontSize="12"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           HorizontalAlignment="Center"/>
+                <!-- Cancel affordance -->
+                <Button Content="Cancel"
+                        Command="{Binding CancelOperationCommand}"
+                        IsVisible="{Binding IsCancellable}"
+                        HorizontalAlignment="Center"/>
             </StackPanel>
         </Border>
     </Grid>

--- a/teams-phonemanager.Tests/PowerShellContextServiceTests.cs
+++ b/teams-phonemanager.Tests/PowerShellContextServiceTests.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using teams_phonemanager.Services;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Integration coverage for the async execution foundations added in issue #61: cooperative
+    /// cancellation (which must leave the persistent runspace reusable) and native PowerShell progress
+    /// forwarding. These spin up a real runspace, so they are slower than the pure unit tests but are the
+    /// only way to prove the runspace-reuse contract.
+    /// </summary>
+    public class PowerShellContextServiceTests
+    {
+        /// <summary>Captures IProgress reports synchronously (the service reports on the pipeline thread).</summary>
+        private sealed class CapturingProgress : IProgress<PowerShellProgress>
+        {
+            private readonly object _gate = new();
+            public List<PowerShellProgress> Reports { get; } = new();
+
+            public void Report(PowerShellProgress value)
+            {
+                lock (_gate) { Reports.Add(value); }
+            }
+        }
+
+        private static PowerShellContextService CreateService()
+            => new(new LoggingService());
+
+        [Fact]
+        public async Task Cancellation_stops_long_running_command_and_leaves_runspace_reusable()
+        {
+            using var service = CreateService();
+            using var cts = new CancellationTokenSource();
+
+            // A command that would otherwise block for 30s; cancellation must interrupt it far sooner.
+            var running = service.ExecuteCommandWithDetailsAsync(
+                "Start-Sleep -Seconds 30; 'should-not-reach'", null, null, cts.Token);
+
+            // Give the pipeline a moment to actually start before requesting cancellation.
+            await Task.Delay(500);
+
+            var sw = Stopwatch.StartNew();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => running);
+            sw.Stop();
+
+            // Proves cancellation was cooperative (Stop() interrupted the sleep) rather than waiting it out.
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(15),
+                $"Cancellation took {sw.Elapsed.TotalSeconds:F1}s — it should interrupt the pipeline promptly.");
+
+            // The runspace must remain open and reusable: a follow-up command runs normally.
+            var followUp = await service.ExecuteCommandWithDetailsAsync("'still-alive'", null, null, default);
+            Assert.Contains("still-alive", followUp.Output);
+            Assert.False(followUp.HadErrors);
+        }
+
+        [Fact]
+        public async Task Progress_records_are_forwarded_to_the_supplied_IProgress()
+        {
+            using var service = CreateService();
+            var progress = new CapturingProgress();
+
+            var result = await service.ExecuteCommandWithDetailsAsync(
+                "Write-Progress -Activity 'Provisioning' -Status 'Working' -PercentComplete 42; 'done'",
+                null, progress, default);
+
+            Assert.Contains("done", result.Output);
+            Assert.Contains(progress.Reports, r =>
+                r.Activity == "Provisioning" &&
+                r.PercentComplete == 42 &&
+                !r.IsIndeterminate);
+        }
+
+        [Fact]
+        public async Task Command_without_percent_is_reported_as_indeterminate()
+        {
+            using var service = CreateService();
+            var progress = new CapturingProgress();
+
+            await service.ExecuteCommandWithDetailsAsync(
+                "Write-Progress -Activity 'Scanning' -Status 'Please wait'; 'ok'",
+                null, progress, default);
+
+            Assert.Contains(progress.Reports, r => r.Activity == "Scanning" && r.IsIndeterminate);
+        }
+
+        [Fact]
+        public async Task Concurrent_executions_are_serialized_not_interleaved()
+        {
+            using var service = CreateService();
+
+            // Two commands that each append a distinct token with a small delay between two writes.
+            // If they interleaved on the shared runspace the outputs would be intermixed; the semaphore
+            // guarantees the first completes fully before the second starts.
+            var first = service.ExecuteCommandWithDetailsAsync(
+                "'A-start'; Start-Sleep -Milliseconds 400; 'A-end'", null, null, default);
+            var second = service.ExecuteCommandWithDetailsAsync(
+                "'B-start'; 'B-end'", null, null, default);
+
+            var results = await Task.WhenAll(first, second);
+
+            // Each result contains only its own tokens — no cross-contamination between pipelines.
+            Assert.Contains("A-start", results[0].Output);
+            Assert.Contains("A-end", results[0].Output);
+            Assert.DoesNotContain("B-start", results[0].Output);
+
+            Assert.Contains("B-start", results[1].Output);
+            Assert.DoesNotContain("A-start", results[1].Output);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #61. **Stacked on #81** (typed OperationResult) — merge that first; GitHub will retarget this PR to main.

### Design
- **Real cancellation**: `CancellationToken.Register` → `PowerShell.Stop()` interrupts the running pipeline; runspace stays `Opened` and reusable (commands/streams cleared per-run, env-var and semaphore `finally` blocks run on the cancel path). Surfaced as `OperationCanceledException`; ViewModels show "cancelled" status with **no error dialog**.
- **Progress**: observes the native `Write-Progress` stream (`Streams.Progress.DataAdded`) and forwards a framework-free `PowerShellProgress` via `IProgress<T>` — determinate when `PercentComplete >= 0`, indeterminate otherwise. Purely observational; zero script text changes. Handler unsubscribed in `finally`.
- **UI**: Cancel button + determinate progress binding added to the six views that already had busy overlays (Wizard, CallQueues, AutoAttendants, Holidays, M365Groups, BulkOperations). Wizard's existing "Step X/10" bar unchanged.
- **Preserved**: semaphore serialization, session-expiry detection, #60 `ShouldReportError` semantics.
- New `Cancelled` error category; a cancelled wizard step reads as failed/retryable (never falsely "completed").

### Verification (independent pass)
- `dotnet build` — 0 warnings, 0 errors (warnings-as-errors)
- `dotnet test` — **151/151 passed** (4 new integration tests: cancel-then-reuse runspace, determinate + indeterminate progress forwarding, serialized concurrency)
- Diff vs #60 branch confirmed: no ScriptBuilder, MSAL/auth, or script-generation files touched; snapshot tests unchanged

### Note
The new integration tests spin up a real runspace (~1s each) — the only way to prove the runspace-reuse contract.