### PR TITLE
chore: bump version to 3.19.0

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity 
-    version="3.18.0.0"
+    version="3.19.0.0"
     name="TeamsPhoneManager"
     processorArchitecture="*"
     type="win32"/>

--- a/src/TeamsPhoneManager.Domain/ConstantsService.cs
+++ b/src/TeamsPhoneManager.Domain/ConstantsService.cs
@@ -51,7 +51,7 @@ namespace teams_phonemanager.Services
 
         public static class Application
         {
-            public const string Version = "Version 3.18.0";
+            public const string Version = "Version 3.19.0";
             public const string Copyright = "Realgar © 2026. MIT License.";
         }
 

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -5,9 +5,9 @@
          EnableNETAnalyzers and AnalysisLevel are inherited from Directory.Build.props. -->
     <OutputType>WinExe</OutputType>
     <RootNamespace>teams_phonemanager</RootNamespace>
-    <Version>3.18.0</Version>
-    <AssemblyVersion>3.18.0</AssemblyVersion>
-    <FileVersion>3.18.0</FileVersion>
+    <Version>3.19.0</Version>
+    <AssemblyVersion>3.19.0</AssemblyVersion>
+    <FileVersion>3.19.0</FileVersion>
     
     <!-- Publish Settings for Framework-Dependent Deployment -->
     <PublishSingleFile>false</PublishSingleFile>


### PR DESCRIPTION
Version bump only (3.18.0 → 3.19.0) to cut a new release.

Files: `teams-phonemanager.csproj`, `app.manifest`, `src/TeamsPhoneManager.Domain/ConstantsService.cs` — updated via `Scripts/bump-version.sh minor`.

Merging to main triggers the release workflow, which auto-tags `v3.19.0`, builds all platform artifacts, publishes the GitHub release, and bumps the Homebrew cask.