### PR TITLE
Improve Windows update and deployment experience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,10 @@ jobs:
     - name: List downloaded artifacts
       run: ls -lh artifacts/
 
+    - name: Generate SHA-256 manifest
+      working-directory: artifacts
+      run: sha256sum teams-phonemanager-* > SHA256SUMS
+
     - name: Create Release
       uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981 # v2.0.8
       with:
@@ -225,6 +229,7 @@ jobs:
           artifacts/teams-phonemanager-osx-x64.zip
           artifacts/teams-phonemanager-osx-arm64.zip
           artifacts/teams-phonemanager-linux-x64.zip
+          artifacts/SHA256SUMS
         fail_on_unmatched_files: true
         draft: false
         prerelease: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Realgar
+Copyright (c) 2026 Patrik Lleshaj
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Program.cs
+++ b/Program.cs
@@ -49,6 +49,7 @@ class Program
         services.AddSingleton<IMsalGraphAuthenticationService, MsalGraphAuthenticationService>();
         services.AddSingleton<ISharedStateService, SharedStateService>();
         services.AddSingleton<IUpdateCheckService, GitHubUpdateCheckService>();
+        services.AddSingleton<IUpdateInstallerService, GitHubUpdateInstallerService>();
         
         // UI Services (singleton - manages UI state)
         services.AddSingleton<IDialogService, DialogService>();
@@ -95,4 +96,3 @@ class Program
             .WithInterFont()
             .LogToTrace();
 }
-

--- a/README.md
+++ b/README.md
@@ -14,35 +14,41 @@
   <b>Manage Microsoft Teams telephony — auto attendants, call queues, and phone numbers — from one desktop app.</b>
 </p>
 
-<p align="center">
-  <a href="#installation">Install</a> ·
-  <a href="#features">Features</a> ·
-  <a href="#screenshots">Screenshots</a> ·
-  <a href="#architecture">Architecture</a> ·
-  <a href="#contributing">Contributing</a>
-</p>
-
----
-
-Teams Phone Manager is an Avalonia-based desktop app, built on .NET 10, that streamlines
-Microsoft Teams Phone System administration — no PowerShell scripting required. It runs
-natively on Windows, macOS, and Linux.
+Teams Phone Manager is a self-contained .NET desktop app for administering Microsoft
+Teams Phone without writing PowerShell.
 
 ## Features
 
-- **Auto Attendants** — create, configure, and manage call routing menus
-- **Call Queues** — set up and maintain queue distribution and agent lists
-- **Holidays** — manage holiday schedules with built-in regional computus support
-- **365 Groups** — integrate resource accounts with Microsoft 365 Groups
-- **Resource Accounts** — provision and assign telephony resource accounts
-- **Modern UI** — a fast, native, dark/light-themed interface
+- Auto attendants, call queues, holidays, resource accounts, and Microsoft 365 Groups
+- Guided setup, bulk operations, and tenant documentation
+- Native Windows, macOS, and Linux builds with dark and light themes
 
 ## Installation
 
-Builds are self-contained — no .NET runtime install required. The Microsoft Teams &
-Graph PowerShell modules and PowerShell 7 are included with the app.
+Download the latest build from [GitHub Releases](https://github.com/realgarit/teams-phonemanager/releases/latest).
+PowerShell 7 and the required Microsoft modules are included.
 
-### macOS (Homebrew — recommended)
+### Windows
+
+Run `teams-phonemanager-win-x64-setup.exe`. It supports per-user and all-users
+installation and upgrades in place. Until code signing is enabled, Windows may show a
+SmartScreen warning.
+
+Portable alternative: download `teams-phonemanager-win-x64.zip`, extract, run
+`teams-phonemanager.exe`.
+
+#### Enterprise deployment
+
+For Intune, Configuration Manager, or an RMM:
+
+```powershell
+.\teams-phonemanager-win-x64-setup.exe /ALLUSERS /DIR="C:\Program Files\Teams Phone Manager" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+```
+
+Use `/CURRENTUSER` for per-user deployment and `/DIR="C:\Path"` for a managed install
+location. Keep the same scope and path when upgrading.
+
+### macOS
 
 ```bash
 brew tap realgarit/tap
@@ -50,27 +56,8 @@ brew trust realgarit/tap
 brew install --cask teams-phonemanager
 ```
 
-(`brew trust` is only needed once — newer Homebrew requires trusting third-party taps.)
-
-Update later with `brew upgrade --cask teams-phonemanager`.
-
-Manual alternative: download `teams-phonemanager-osx-arm64.zip` (Apple Silicon) or
-`teams-phonemanager-osx-x64.zip` (Intel) from the
-[latest release](https://github.com/realgarit/teams-phonemanager/releases/latest),
-unzip, and drag **Teams Phone Manager.app** to Applications. The app is not notarized,
-so for a manual download you must clear the quarantine flag once:
-`xattr -dr com.apple.quarantine "/Applications/Teams Phone Manager.app"`.
-
-### Windows (installer — recommended)
-
-Download `teams-phonemanager-win-x64-setup.exe` from the
-[latest release](https://github.com/realgarit/teams-phonemanager/releases/latest) and run it.
-It installs per-user (no admin rights needed) with a Start-menu shortcut and uninstaller.
-The installer is not code-signed yet, so SmartScreen may warn — choose
-**More info → Run anyway**. Running a newer installer upgrades in place.
-
-Portable alternative: download `teams-phonemanager-win-x64.zip`, extract, run
-`teams-phonemanager.exe`.
+Update with `brew upgrade --cask teams-phonemanager`. Manual Apple Silicon and Intel
+downloads are also available on the releases page.
 
 ### Linux
 
@@ -81,112 +68,25 @@ chmod +x teams-phonemanager
 ./teams-phonemanager
 ```
 
-### Staying up to date
+## Updates
 
-The app checks GitHub Releases on startup and shows a banner when a newer version is
-available (silent when offline).
+The app checks GitHub Releases at startup and shows a non-blocking update indicator.
+On Windows, updates can be downloaded, SHA-256 verified, and installed in the app.
+macOS and Linux updates continue through Homebrew or GitHub Releases.
 
-## Prerequisites
+## Development
 
-- Windows 10/11, Windows Server 2019+, macOS 12+, or Linux (Ubuntu 20.04+)
-- Microsoft Teams & Graph PowerShell Module (included with the app)
-- PowerShell 7.4+ (included with the app)
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
-## Screenshots
-
-<details open>
-<summary><b>Core workflows</b></summary>
-<br/>
-
-| | |
-|---|---|
-| **Welcome** <br/> <img src="docs/screenshots/welcome.png" width="480" alt="Welcome page (dark theme)"/> | **Get Started** <br/> <img src="docs/screenshots/get-started.png" width="480" alt="Get Started page with connection steps"/> |
-| **Variables** <br/> <img src="docs/screenshots/variables.png" width="480" alt="Variables configuration page"/> | **M365 Groups** <br/> <img src="docs/screenshots/m365-groups.png" width="480" alt="M365 Groups management"/> |
-| **Call Queues** <br/> <img src="docs/screenshots/call-queues.png" width="480" alt="Call Queues management"/> | **Auto Attendants** <br/> <img src="docs/screenshots/auto-attendants.png" width="480" alt="Auto Attendants management"/> |
-
-</details>
-
-<details>
-<summary><b>More: holidays, setup wizard, bulk ops, documentation, light theme</b></summary>
-<br/>
-
-| | |
-|---|---|
-| **Holidays** <br/> <img src="docs/screenshots/holidays.png" width="480" alt="Holiday management"/> | **Setup Wizard** <br/> <img src="docs/screenshots/setup-wizard.png" width="480" alt="Step-by-step setup wizard"/> |
-| **Bulk Operations** <br/> <img src="docs/screenshots/bulk-operations.png" width="480" alt="CSV bulk operations"/> | **Documentation** <br/> <img src="docs/screenshots/documentation.png" width="480" alt="Tenant documentation export"/> |
-| **Light Theme** <br/> <img src="docs/screenshots/welcome-light.png" width="480" alt="Welcome page (light theme)"/> | |
-
-</details>
-
-## Architecture
-
-The solution follows **Clean Architecture** (Robert C. Martin): four layers as separate
-assemblies with dependencies pointing strictly inward. The Dependency Rule is enforced at
-build time by `DependencyRuleTests` (the build fails if a forbidden dependency leaks inward).
-
-- **Domain** — framework-free business rules and value objects (validation rules, the Swiss
-  holiday computus, naming/UPN contracts, constants). Zero framework dependencies.
-- **Application** — use-case orchestration and the ports (interfaces) the outer layers implement.
-- **Infrastructure** — adapters to the outside world; the only layer that references
-  `System.Management.Automation` and `Microsoft.Identity.Client`. Holds the PowerShell script
-  builders and the MSAL/Graph authentication flow.
-- **Presentation** — the Avalonia/MVVM UI (FluentAvalonia, custom dark/light theme); depends only
-  on Domain + Application. VM-first view resolution via a `ViewLocator` (no service locator).
-- The **executable** (`teams-phonemanager`) is the composition root: it wires implementations to
-  ports via dependency injection and references all four layers.
-
-Tech: .NET 10, Avalonia, CommunityToolkit.Mvvm, Microsoft.PowerShell.SDK, MSAL.
-
-## Project Structure
-
-```
-teams-phonemanager/
-├── Program.cs                         # Composition root (DI wiring, app entry point)
-├── teams-phonemanager.csproj          # Executable (references all four layers)
-├── TeamsPhoneManager.slnx             # Solution
-├── Directory.Build.props              # Shared compiler/analyzer settings
-├── src/
-│   ├── TeamsPhoneManager.Domain/         # Entities, rules, value objects (no frameworks)
-│   ├── TeamsPhoneManager.Application/     # Use cases + ports (interfaces)
-│   ├── TeamsPhoneManager.Infrastructure/  # PowerShell/Graph adapters (frozen script builders)
-│   └── TeamsPhoneManager.Presentation/    # Avalonia Views, ViewModels, Converters, Resources
-├── teams-phonemanager.Tests/          # xUnit tests incl. Dependency-Rule guards
-└── Scripts/                           # Publish & download PowerShell modules
+```bash
+dotnet restore
+dotnet build
+dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj
+dotnet run
 ```
 
-## Development Setup
-
-1. Install .NET 10 SDK:
-   ```bash
-   # Download from: https://dotnet.microsoft.com/download/dotnet/10.0
-   ```
-
-2. Restore dependencies:
-   ```bash
-   dotnet restore
-   ```
-
-3. Build the application:
-   ```bash
-   dotnet build
-   ```
-
-4. Run the application:
-   ```bash
-   dotnet run
-   ```
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test thoroughly
-5. Submit a [pull request](https://github.com/realgarit/teams-phonemanager/pulls)
-
-Found a bug or have a feature request? Open an
-[issue](https://github.com/realgarit/teams-phonemanager/issues).
+Built with Avalonia, CommunityToolkit.Mvvm, Microsoft.PowerShell.SDK, and MSAL.
 
 ## License
 
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+MIT © 2026 Patrik Lleshaj. See [LICENSE](LICENSE).

--- a/Scripts/package-macos.sh
+++ b/Scripts/package-macos.sh
@@ -78,7 +78,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright © 2026 Realgar. MIT License.</string>
+    <string>Copyright © 2026 Patrik Lleshaj. MIT License.</string>
 </dict>
 </plist>
 PLIST

--- a/installer/windows/teams-phonemanager.iss
+++ b/installer/windows/teams-phonemanager.iss
@@ -11,7 +11,7 @@
 
 #define AppName "Teams Phone Manager"
 #define AppExeName "teams-phonemanager.exe"
-#define AppPublisher "Realgar"
+#define AppPublisher "Patrik Lleshaj"
 #define AppURL "https://github.com/realgarit/teams-phonemanager"
 
 [Setup]
@@ -19,13 +19,16 @@
 AppId={{8E1D3A5B-6C0F-4D9E-9B7A-2F4C1A7E5D21}
 AppName={#AppName}
 AppVersion={#AppVersion}
+AppVerName={#AppName}
 AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}
 AppSupportURL={#AppURL}/issues
 AppUpdatesURL={#AppURL}/releases
-DefaultDirName={localappdata}\Programs\TeamsPhoneManager
+DefaultDirName={autopf}\TeamsPhoneManager
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog commandline
+UsePreviousPrivileges=yes
 OutputBaseFilename=teams-phonemanager-win-x64-setup
 SetupIconFile=..\..\assets\icon.ico
 UninstallDisplayIcon={app}\{#AppExeName}
@@ -47,8 +50,15 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{userprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
-Name: "{userdesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent runasoriginaluser
+Filename: "{app}\{#AppExeName}"; Flags: nowait skipifnotsilent runasoriginaluser; Check: ShouldRestartApplication
+
+[Code]
+function ShouldRestartApplication(): Boolean;
+begin
+  Result := ExpandConstant('{param:RESTARTAPP|0}') = '1';
+end;

--- a/src/TeamsPhoneManager.Application/Interfaces/IUpdateCheckService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IUpdateCheckService.cs
@@ -13,4 +13,13 @@ public interface IUpdateCheckService
 }
 
 /// <summary>A newer release available for download.</summary>
-public sealed record UpdateInfo(string LatestVersion, string ReleaseUrl);
+public sealed record UpdateInfo(
+    string LatestVersion,
+    string ReleaseUrl,
+    UpdateAsset? WindowsInstaller = null);
+
+/// <summary>A release asset whose integrity can be verified before execution.</summary>
+public sealed record UpdateAsset(
+    string Name,
+    string DownloadUrl,
+    string Sha256);

--- a/src/TeamsPhoneManager.Application/Interfaces/IUpdateInstallerService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IUpdateInstallerService.cs
@@ -1,0 +1,36 @@
+namespace teams_phonemanager.Services.Interfaces;
+
+/// <summary>
+/// Downloads, verifies, and launches the native Windows update installer.
+/// </summary>
+public interface IUpdateInstallerService
+{
+    bool IsSupported { get; }
+
+    Task<string> DownloadInstallerAsync(
+        UpdateAsset asset,
+        IProgress<UpdateDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+
+    void LaunchInstaller(string installerPath);
+}
+
+public sealed record UpdateDownloadProgress(long BytesReceived, long? TotalBytes)
+{
+    public int Percentage => TotalBytes is > 0
+        ? (int)Math.Clamp(BytesReceived * 100 / TotalBytes.Value, 0, 100)
+        : 0;
+}
+
+public sealed class UpdateInstallationException : Exception
+{
+    public UpdateInstallationException(string message)
+        : base(message)
+    {
+    }
+
+    public UpdateInstallationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/TeamsPhoneManager.Domain/ConstantsService.cs
+++ b/src/TeamsPhoneManager.Domain/ConstantsService.cs
@@ -52,7 +52,7 @@ namespace teams_phonemanager.Services
         public static class Application
         {
             public const string Version = "Version 3.19.0";
-            public const string Copyright = "Realgar © 2026. MIT License.";
+            public const string Copyright = "Patrik Lleshaj © 2026. MIT License.";
         }
 
         public static class Messages

--- a/src/TeamsPhoneManager.Infrastructure/GitHubUpdateCheckService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/GitHubUpdateCheckService.cs
@@ -14,17 +14,25 @@ public sealed class GitHubUpdateCheckService : IUpdateCheckService
 {
     private const string LatestReleaseApi =
         "https://api.github.com/repos/realgarit/teams-phonemanager/releases/latest";
+    private const string WindowsInstallerName = "teams-phonemanager-win-x64-setup.exe";
 
     private readonly string _currentVersionText;
+    private readonly HttpClient _httpClient;
 
     public GitHubUpdateCheckService()
-        : this(ConstantsService.Application.Version)
+        : this(ConstantsService.Application.Version, CreateHttpClient())
     {
     }
 
     public GitHubUpdateCheckService(string currentVersionText)
+        : this(currentVersionText, CreateHttpClient())
+    {
+    }
+
+    public GitHubUpdateCheckService(string currentVersionText, HttpClient httpClient)
     {
         _currentVersionText = currentVersionText;
+        _httpClient = httpClient;
     }
 
     public async Task<UpdateInfo?> CheckForUpdateAsync(CancellationToken cancellationToken = default)
@@ -36,13 +44,7 @@ public sealed class GitHubUpdateCheckService : IUpdateCheckService
 
         try
         {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-            http.DefaultRequestHeaders.UserAgent.Add(
-                new ProductInfoHeaderValue("teams-phonemanager", current.ToString()));
-            http.DefaultRequestHeaders.Accept.Add(
-                new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
-
-            using var response = await http.GetAsync(LatestReleaseApi, cancellationToken).ConfigureAwait(false);
+            using var response = await _httpClient.GetAsync(LatestReleaseApi, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 return null;
@@ -63,11 +65,69 @@ public sealed class GitHubUpdateCheckService : IUpdateCheckService
                 return null;
             }
 
-            return latest.IsNewerThan(current) ? new UpdateInfo(latest.ToString(), url) : null;
+            if (!latest.IsNewerThan(current))
+            {
+                return null;
+            }
+
+            var installer = TryGetWindowsInstaller(doc.RootElement);
+            return new UpdateInfo(latest.ToString(), url, installer);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return null;
         }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        httpClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue(new ProductHeaderValue("teams-phonemanager")));
+        httpClient.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        return httpClient;
+    }
+
+    private static UpdateAsset? TryGetWindowsInstaller(JsonElement release)
+    {
+        if (!release.TryGetProperty("assets", out var assets) ||
+            assets.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var asset in assets.EnumerateArray())
+        {
+            var name = asset.TryGetProperty("name", out var nameElement)
+                ? nameElement.GetString()
+                : null;
+
+            if (!string.Equals(name, WindowsInstallerName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var downloadUrl = asset.TryGetProperty("browser_download_url", out var urlElement)
+                ? urlElement.GetString()
+                : null;
+            var digest = asset.TryGetProperty("digest", out var digestElement)
+                ? digestElement.GetString()
+                : null;
+
+            if (downloadUrl is null ||
+                digest is null ||
+                !digest.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var sha256 = digest["sha256:".Length..];
+            return sha256.Length == 64 && sha256.All(Uri.IsHexDigit)
+                ? new UpdateAsset(WindowsInstallerName, downloadUrl, sha256)
+                : null;
+        }
+
+        return null;
     }
 }

--- a/src/TeamsPhoneManager.Infrastructure/GitHubUpdateInstallerService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/GitHubUpdateInstallerService.cs
@@ -1,0 +1,265 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Services;
+
+/// <summary>
+/// Downloads the Windows installer from GitHub, verifies its release digest, and launches it.
+/// </summary>
+public sealed class GitHubUpdateInstallerService : IUpdateInstallerService
+{
+    private const string WindowsInstallerName = "teams-phonemanager-win-x64-setup.exe";
+    private const long MaximumInstallerBytes = 512L * 1024 * 1024;
+    private readonly HttpClient _httpClient;
+
+    public GitHubUpdateInstallerService()
+        : this(CreateHttpClient())
+    {
+    }
+
+    public GitHubUpdateInstallerService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        CleanupPreviousDownloads();
+    }
+
+    public bool IsSupported => OperatingSystem.IsWindows();
+
+    public async Task<string> DownloadInstallerAsync(
+        UpdateAsset asset,
+        IProgress<UpdateDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateAsset(asset);
+
+        string? downloadDirectory = null;
+
+        try
+        {
+            downloadDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "TeamsPhoneManager",
+                Guid.NewGuid().ToString("N"));
+            var installerPath = Path.Combine(downloadDirectory, WindowsInstallerName);
+            Directory.CreateDirectory(downloadDirectory);
+
+            using var response = await _httpClient.GetAsync(
+                asset.DownloadUrl,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var totalBytes = response.Content.Headers.ContentLength;
+            if (totalBytes > MaximumInstallerBytes)
+            {
+                throw new UpdateInstallationException("The update installer is unexpectedly large.");
+            }
+
+            await using var source = await response.Content
+                .ReadAsStreamAsync(cancellationToken)
+                .ConfigureAwait(false);
+            await using var destination = new FileStream(
+                installerPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                81920,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+            var buffer = new byte[81920];
+            long bytesReceived = 0;
+            progress?.Report(new UpdateDownloadProgress(0, totalBytes));
+
+            while (true)
+            {
+                var bytesRead = await source
+                    .ReadAsync(buffer, cancellationToken)
+                    .ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                bytesReceived += bytesRead;
+                if (bytesReceived > MaximumInstallerBytes)
+                {
+                    throw new UpdateInstallationException("The update installer is unexpectedly large.");
+                }
+
+                hash.AppendData(buffer.AsSpan(0, bytesRead));
+                await destination
+                    .WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken)
+                    .ConfigureAwait(false);
+                progress?.Report(new UpdateDownloadProgress(bytesReceived, totalBytes));
+            }
+
+            await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+            var actualSha256 = Convert.ToHexString(hash.GetHashAndReset());
+            if (!string.Equals(actualSha256, asset.Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UpdateInstallationException(
+                    "The downloaded installer failed its integrity check and was deleted.");
+            }
+
+            return installerPath;
+        }
+        catch (OperationCanceledException)
+        {
+            DeleteDownloadDirectory(downloadDirectory);
+            throw;
+        }
+        catch (UpdateInstallationException)
+        {
+            DeleteDownloadDirectory(downloadDirectory);
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            DeleteDownloadDirectory(downloadDirectory);
+            throw new UpdateInstallationException("The update installer could not be downloaded.", ex);
+        }
+        catch (IOException ex)
+        {
+            DeleteDownloadDirectory(downloadDirectory);
+            throw new UpdateInstallationException("The update installer could not be saved.", ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            DeleteDownloadDirectory(downloadDirectory);
+            throw new UpdateInstallationException("The update installer could not be saved.", ex);
+        }
+    }
+
+    public void LaunchInstaller(string installerPath)
+    {
+        if (!IsSupported)
+        {
+            throw new UpdateInstallationException(
+                "Automatic installation is currently available on Windows only.");
+        }
+
+        if (!File.Exists(installerPath) ||
+            !string.Equals(Path.GetFileName(installerPath), WindowsInstallerName, StringComparison.Ordinal))
+        {
+            throw new UpdateInstallationException("The verified update installer could not be found.");
+        }
+
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = installerPath,
+                Arguments = "/SILENT /NORESTART /CLOSEAPPLICATIONS /RESTARTAPP=1",
+                WorkingDirectory = Path.GetDirectoryName(installerPath),
+                UseShellExecute = true
+            });
+
+            if (process is null)
+            {
+                throw new UpdateInstallationException("The update installer could not be started.");
+            }
+        }
+        catch (Win32Exception ex)
+        {
+            throw new UpdateInstallationException("The update installer could not be started.", ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new UpdateInstallationException("The update installer could not be started.", ex);
+        }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        httpClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue(new ProductHeaderValue("teams-phonemanager-updater")));
+        return httpClient;
+    }
+
+    private static void CleanupPreviousDownloads()
+    {
+        try
+        {
+            var rootDirectory = Path.Combine(Path.GetTempPath(), "TeamsPhoneManager");
+            if (!Directory.Exists(rootDirectory))
+            {
+                return;
+            }
+
+            foreach (var downloadDirectory in Directory.GetDirectories(rootDirectory))
+            {
+                try
+                {
+                    Directory.Delete(downloadDirectory, recursive: true);
+                }
+                catch (IOException ex)
+                {
+                    Trace.TraceWarning(
+                        "Could not remove previous update download '{0}': {1}",
+                        downloadDirectory,
+                        ex.Message);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    Trace.TraceWarning(
+                        "Could not remove previous update download '{0}': {1}",
+                        downloadDirectory,
+                        ex.Message);
+                }
+            }
+        }
+        catch (IOException ex)
+        {
+            Trace.TraceWarning("Could not inspect previous update downloads: {0}", ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Trace.TraceWarning("Could not inspect previous update downloads: {0}", ex.Message);
+        }
+    }
+
+    private static void ValidateAsset(UpdateAsset asset)
+    {
+        if (!string.Equals(asset.Name, WindowsInstallerName, StringComparison.Ordinal) ||
+            !Uri.TryCreate(asset.DownloadUrl, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase) ||
+            asset.Sha256.Length != 64 ||
+            !asset.Sha256.All(Uri.IsHexDigit))
+        {
+            throw new UpdateInstallationException("The release does not contain a valid Windows installer.");
+        }
+    }
+
+    private static void DeleteDownloadDirectory(string? directory)
+    {
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException ex)
+        {
+            Trace.TraceWarning(
+                "Could not remove rejected update download '{0}': {1}",
+                directory,
+                ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Trace.TraceWarning(
+                "Could not remove rejected update download '{0}': {1}",
+                directory,
+                ex.Message);
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/MainWindow.axaml
+++ b/src/TeamsPhoneManager.Presentation/MainWindow.axaml
@@ -64,6 +64,19 @@
                                            FontSize="10"
                                            VerticalAlignment="Center"
                                            Opacity="0.45"/>
+                                <Button Content="UPDATE"
+                                        Command="{Binding ShowUpdateBannerCommand}"
+                                        IsVisible="{Binding IsUpdateAvailable}"
+                                        ToolTip.Tip="{Binding UpdateBannerMessage}"
+                                        FontSize="8"
+                                        FontWeight="SemiBold"
+                                        Foreground="White"
+                                        Background="{DynamicResource TeamsPrimaryBrush}"
+                                        BorderThickness="0"
+                                        CornerRadius="5"
+                                        Padding="5,1"
+                                        MinHeight="0"
+                                        VerticalAlignment="Center"/>
                             </StackPanel>
                         </StackPanel>
                     </StackPanel>
@@ -546,8 +559,23 @@
                     MinWidth="420"
                     Margin="0,8,0,0">
             <ui:InfoBar.ActionButton>
-                <Button Content="View release" Command="{Binding OpenUpdatePageCommand}"/>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="Install update"
+                            Command="{Binding InstallUpdateCommand}"
+                            IsVisible="{Binding CanInstallUpdate}"/>
+                    <Button Content="Cancel"
+                            Command="{Binding CancelUpdateCommand}"
+                            IsVisible="{Binding IsUpdateInProgress}"/>
+                    <Button Content="View release" Command="{Binding OpenUpdatePageCommand}"/>
+                </StackPanel>
             </ui:InfoBar.ActionButton>
+            <ProgressBar Width="360"
+                         Margin="0,8,0,0"
+                         Minimum="0"
+                         Maximum="100"
+                         Value="{Binding UpdateDownloadProgress}"
+                         IsIndeterminate="{Binding IsUpdateProgressIndeterminate}"
+                         IsVisible="{Binding IsUpdateInProgress}"/>
         </ui:InfoBar>
     </Grid>
 </Window>

--- a/src/TeamsPhoneManager.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/MainWindowViewModel.cs
@@ -27,12 +27,31 @@ namespace teams_phonemanager.ViewModels
 
         private readonly IPageViewModelFactory _pageViewModelFactory;
         private readonly IUpdateCheckService _updateCheckService;
+        private readonly IUpdateInstallerService _updateInstallerService;
+        private readonly IDialogService _updateDialogService;
+        private UpdateInfo? _availableUpdate;
+        private CancellationTokenSource? _updateCancellation;
 
         [ObservableProperty]
         private bool _isUpdateBannerVisible;
 
         [ObservableProperty]
+        private bool _isUpdateAvailable;
+
+        [ObservableProperty]
         private string _updateBannerMessage = string.Empty;
+
+        [ObservableProperty]
+        private bool _canInstallUpdate;
+
+        [ObservableProperty]
+        private bool _isUpdateInProgress;
+
+        [ObservableProperty]
+        private bool _isUpdateProgressIndeterminate;
+
+        [ObservableProperty]
+        private double _updateDownloadProgress;
 
         private string? _updateReleaseUrl;
 
@@ -44,10 +63,108 @@ namespace teams_phonemanager.ViewModels
                 return;
             }
 
+            _availableUpdate = update;
             _updateReleaseUrl = update.ReleaseUrl;
             UpdateBannerMessage = $"Version {update.LatestVersion} is available.";
+            CanInstallUpdate = _updateInstallerService.IsSupported && update.WindowsInstaller is not null;
+            IsUpdateAvailable = true;
             IsUpdateBannerVisible = true;
             _loggingService.Log($"Update available: {update.LatestVersion}", LogLevel.Info);
+        }
+
+        partial void OnCanInstallUpdateChanged(bool value)
+        {
+            InstallUpdateCommand.NotifyCanExecuteChanged();
+        }
+
+        partial void OnIsUpdateInProgressChanged(bool value)
+        {
+            InstallUpdateCommand.NotifyCanExecuteChanged();
+            CancelUpdateCommand.NotifyCanExecuteChanged();
+        }
+
+        private bool CanInstallUpdateNow() => CanInstallUpdate && !IsUpdateInProgress;
+
+        [RelayCommand(CanExecute = nameof(CanInstallUpdateNow))]
+        private async Task InstallUpdateAsync()
+        {
+            var update = _availableUpdate;
+            if (update?.WindowsInstaller is not { } installer)
+            {
+                _loggingService.Log("No verified Windows update installer is available.", LogLevel.Warning);
+                return;
+            }
+
+            var confirmed = await _updateDialogService.ShowConfirmationAsync(
+                "Install update",
+                $"Download and install version {update.LatestVersion}? " +
+                "Teams Phone Manager will close and restart automatically.");
+            if (!confirmed)
+            {
+                return;
+            }
+
+            _updateCancellation?.Dispose();
+            _updateCancellation = new CancellationTokenSource();
+            IsUpdateInProgress = true;
+            IsUpdateProgressIndeterminate = true;
+            UpdateDownloadProgress = 0;
+            UpdateBannerMessage = $"Downloading version {update.LatestVersion}...";
+
+            var progress = new Progress<UpdateDownloadProgress>(download =>
+            {
+                IsUpdateProgressIndeterminate = download.TotalBytes is not > 0;
+                UpdateDownloadProgress = download.Percentage;
+                UpdateBannerMessage = download.TotalBytes is > 0
+                    ? $"Downloading version {update.LatestVersion}... {download.Percentage}%"
+                    : $"Downloading version {update.LatestVersion}...";
+            });
+
+            try
+            {
+                var installerPath = await _updateInstallerService.DownloadInstallerAsync(
+                    installer,
+                    progress,
+                    _updateCancellation.Token);
+
+                UpdateBannerMessage = "Starting the verified installer...";
+                _updateInstallerService.LaunchInstaller(installerPath);
+                _loggingService.Log(
+                    $"Starting installer for version {update.LatestVersion}",
+                    LogLevel.Info);
+
+                if (Avalonia.Application.Current?.ApplicationLifetime is
+                    Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                {
+                    desktop.Shutdown();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                UpdateBannerMessage = $"Version {update.LatestVersion} is available.";
+                _loggingService.Log("Update download cancelled.", LogLevel.Info);
+            }
+            catch (UpdateInstallationException ex)
+            {
+                UpdateBannerMessage = $"Version {update.LatestVersion} is available.";
+                _loggingService.Log($"Update installation failed: {ex.Message}", LogLevel.Error);
+                await _updateDialogService.ShowMessageAsync("Update failed", ex.Message);
+            }
+            finally
+            {
+                _updateCancellation.Dispose();
+                _updateCancellation = null;
+                IsUpdateInProgress = false;
+                IsUpdateProgressIndeterminate = false;
+            }
+        }
+
+        private bool CanCancelUpdate() => IsUpdateInProgress;
+
+        [RelayCommand(CanExecute = nameof(CanCancelUpdate))]
+        private void CancelUpdate()
+        {
+            _updateCancellation?.Cancel();
         }
 
         [RelayCommand]
@@ -76,6 +193,12 @@ namespace teams_phonemanager.ViewModels
         private void DismissUpdateBanner()
         {
             IsUpdateBannerVisible = false;
+        }
+
+        [RelayCommand]
+        private void ShowUpdateBanner()
+        {
+            IsUpdateBannerVisible = true;
         }
 
         public ObservableCollection<string> LogEntries => _loggingService.LogEntries;
@@ -227,12 +350,15 @@ namespace teams_phonemanager.ViewModels
             ISharedStateService sharedStateService,
             IDialogService dialogService,
             IPageViewModelFactory pageViewModelFactory,
-            IUpdateCheckService updateCheckService)
+            IUpdateCheckService updateCheckService,
+            IUpdateInstallerService updateInstallerService)
             : base(powerShellContextService, powerShellCommandService, loggingService,
                   sessionManager, navigationService, errorHandlingService, validationService, sharedStateService, dialogService)
         {
             _pageViewModelFactory = pageViewModelFactory;
             _updateCheckService = updateCheckService;
+            _updateInstallerService = updateInstallerService;
+            _updateDialogService = dialogService;
             CurrentViewModel = _pageViewModelFactory.Create(CurrentPage);
 
             _loggingService.Log("Application started", LogLevel.Info);

--- a/teams-phonemanager.Tests/MainWindowViewModelTests.cs
+++ b/teams-phonemanager.Tests/MainWindowViewModelTests.cs
@@ -11,6 +11,7 @@ namespace teams_phonemanager.Tests
     {
         private readonly Mock<IPageViewModelFactory> _pageViewModelFactory = new();
         private readonly Mock<IUpdateCheckService> _updateCheckService = new();
+        private readonly Mock<IUpdateInstallerService> _updateInstallerService = new();
 
         public MainWindowViewModelTests()
         {
@@ -38,7 +39,8 @@ namespace teams_phonemanager.Tests
                 harness.SharedStateService.Object,
                 harness.DialogService.Object,
                 _pageViewModelFactory.Object,
-                _updateCheckService.Object);
+                _updateCheckService.Object,
+                _updateInstallerService.Object);
         }
 
         [Fact]
@@ -72,6 +74,7 @@ namespace teams_phonemanager.Tests
             var vm = CreateViewModel(harness);
 
             Assert.True(vm.IsUpdateBannerVisible);
+            Assert.True(vm.IsUpdateAvailable);
             Assert.Contains("2.0.0", vm.UpdateBannerMessage);
         }
 
@@ -86,6 +89,60 @@ namespace teams_phonemanager.Tests
             vm.DismissUpdateBannerCommand.Execute(null);
 
             Assert.False(vm.IsUpdateBannerVisible);
+            Assert.True(vm.IsUpdateAvailable);
+        }
+
+        [Fact]
+        public async Task InstallUpdateCommand_DownloadsAndLaunchesVerifiedInstaller()
+        {
+            var harness = new ViewModelTestHarness();
+            var asset = new UpdateAsset(
+                "teams-phonemanager-win-x64-setup.exe",
+                "https://github.com/realgarit/teams-phonemanager/releases/download/v2.0.0/setup.exe",
+                new string('a', 64));
+            _updateInstallerService.SetupGet(u => u.IsSupported).Returns(true);
+            _updateInstallerService
+                .Setup(u => u.DownloadInstallerAsync(
+                    asset,
+                    It.IsAny<IProgress<UpdateDownloadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync("verified-setup.exe");
+            _updateCheckService.Setup(u => u.CheckForUpdateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateInfo("2.0.0", "https://example.com/release", asset));
+            var vm = CreateViewModel(harness);
+
+            await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+            _updateInstallerService.Verify(
+                u => u.LaunchInstaller("verified-setup.exe"),
+                Times.Once);
+            Assert.False(vm.IsUpdateInProgress);
+        }
+
+        [Fact]
+        public async Task InstallUpdateCommand_UserDeclines_DoesNotDownload()
+        {
+            var harness = new ViewModelTestHarness();
+            var asset = new UpdateAsset(
+                "teams-phonemanager-win-x64-setup.exe",
+                "https://github.com/realgarit/teams-phonemanager/releases/download/v2.0.0/setup.exe",
+                new string('a', 64));
+            harness.DialogService
+                .Setup(d => d.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+            _updateInstallerService.SetupGet(u => u.IsSupported).Returns(true);
+            _updateCheckService.Setup(u => u.CheckForUpdateAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UpdateInfo("2.0.0", "https://example.com/release", asset));
+            var vm = CreateViewModel(harness);
+
+            await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+            _updateInstallerService.Verify(
+                u => u.DownloadInstallerAsync(
+                    It.IsAny<UpdateAsset>(),
+                    It.IsAny<IProgress<UpdateDownloadProgress>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]

--- a/teams-phonemanager.Tests/UpdateServicesTests.cs
+++ b/teams-phonemanager.Tests/UpdateServicesTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using teams_phonemanager.Services;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Tests;
+
+public sealed class UpdateServicesTests
+{
+    [Fact]
+    public void DefaultServices_UseValidHttpHeaders()
+    {
+        _ = new GitHubUpdateCheckService();
+        _ = new GitHubUpdateInstallerService();
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_ReleaseHasDigest_ReturnsVerifiedInstallerMetadata()
+    {
+        const string digest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        var json = $$"""
+            {
+              "tag_name": "v2.0.0",
+              "html_url": "https://github.com/realgarit/teams-phonemanager/releases/tag/v2.0.0",
+              "assets": [
+                {
+                  "name": "teams-phonemanager-win-x64-setup.exe",
+                  "browser_download_url": "https://github.com/realgarit/teams-phonemanager/releases/download/v2.0.0/teams-phonemanager-win-x64-setup.exe",
+                  "digest": "sha256:{{digest}}"
+                }
+              ]
+            }
+            """;
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            }));
+        var service = new GitHubUpdateCheckService("1.0.0", httpClient);
+
+        var update = await service.CheckForUpdateAsync();
+
+        Assert.NotNull(update);
+        Assert.NotNull(update.WindowsInstaller);
+        Assert.Equal(digest, update.WindowsInstaller.Sha256);
+    }
+
+    [Fact]
+    public async Task DownloadInstallerAsync_ValidDigest_ReturnsVerifiedFile()
+    {
+        var content = Encoding.UTF8.GetBytes("verified installer content");
+        var digest = Convert.ToHexString(SHA256.HashData(content));
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content)
+            }));
+        var service = new GitHubUpdateInstallerService(httpClient);
+        var asset = new UpdateAsset(
+            "teams-phonemanager-win-x64-setup.exe",
+            "https://github.com/realgarit/teams-phonemanager/releases/download/v2.0.0/teams-phonemanager-win-x64-setup.exe",
+            digest);
+
+        var path = await service.DownloadInstallerAsync(asset);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(path));
+        Directory.Delete(Path.GetDirectoryName(path)!, recursive: true);
+    }
+
+    [Fact]
+    public async Task DownloadInstallerAsync_DigestMismatch_RejectsInstaller()
+    {
+        var content = Encoding.UTF8.GetBytes("tampered installer content");
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content)
+            }));
+        var service = new GitHubUpdateInstallerService(httpClient);
+        var asset = new UpdateAsset(
+            "teams-phonemanager-win-x64-setup.exe",
+            "https://github.com/realgarit/teams-phonemanager/releases/download/v2.0.0/teams-phonemanager-win-x64-setup.exe",
+            new string('a', 64));
+
+        var exception = await Assert.ThrowsAsync<UpdateInstallationException>(
+            () => service.DownloadInstallerAsync(asset));
+
+        Assert.Contains("integrity check", exception.Message);
+    }
+
+    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -19,9 +19,10 @@
     <!-- Application Settings -->
     <ApplicationTitle>Teams Phone Manager</ApplicationTitle>
     <ApplicationDescription>An Avalonia-based Microsoft Teams Phone Manager to simplify admin tasks</ApplicationDescription>
-    <Company>Realgar</Company>
+    <Authors>Patrik Lleshaj</Authors>
+    <Company>Patrik Lleshaj</Company>
     <Product>Teams Phone Manager</Product>
-    <Copyright>Copyright © 2026</Copyright>
+    <Copyright>Copyright © 2026 Patrik Lleshaj</Copyright>
     
     <!-- Application Manifest for Windows security and compatibility -->
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
## Summary
- add a persistent update notification and verified in-app Windows installer flow
- support per-user, all-users, and managed installation paths for enterprise deployment
- update publisher and legal metadata to Patrik Lleshaj
- publish release checksums and add updater coverage
- reduce the README from 211 lines to a concise 92-line guide

## Security
- accept only the expected HTTPS GitHub installer asset
- require and verify the release SHA-256 digest before launch
- cap downloads at 512 MB and clean temporary updater files
- restart the installed app as the original user rather than elevated

## Validation
- `dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj -c Release --no-restore` (465 passed)
- `dotnet publish teams-phonemanager.csproj -c Release -r win-x64 --self-contained true --no-restore`
- `bash -n Scripts/package-macos.sh`