### PR TITLE
fix: target repository for release validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         RELEASE_PR: ${{ steps.release.outputs.pr }}
       run: |
         RELEASE_REF="$(jq -r '.headBranchName' <<< "$RELEASE_PR")"
-        gh workflow run build.yml --ref "$RELEASE_REF" -f validate_ref="$RELEASE_REF"
+        gh workflow run build.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_REF" -f validate_ref="$RELEASE_REF"
 
   validate-release:
     name: Validate Release Version


### PR DESCRIPTION
## Summary
- pass the repository explicitly when dispatching Release Please branch validation
- keep the dispatch independent of a local checkout

## Validation
- workflow YAML parses successfully
- a manual dispatch with the same parameters started successfully