### PR TITLE
fix: sync release-please version across all files and fix UI spacing

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity 
-    version="3.19.0.0"
+    version="3.21.1.0" <!-- x-release-please-version -->
     name="TeamsPhoneManager"
     processorArchitecture="*"
     type="win32"/>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,14 @@
         {
           "type": "generic",
           "path": "teams-phonemanager.csproj"
+        },
+        {
+          "type": "generic",
+          "path": "src/TeamsPhoneManager.Domain/ConstantsService.cs"
+        },
+        {
+          "type": "generic",
+          "path": "app.manifest"
         }
       ]
     }

--- a/src/TeamsPhoneManager.Domain/ConstantsService.cs
+++ b/src/TeamsPhoneManager.Domain/ConstantsService.cs
@@ -51,7 +51,7 @@ namespace teams_phonemanager.Services
 
         public static class Application
         {
-            public const string Version = "Version 3.19.0";
+            public const string Version = "Version 3.21.1"; // x-release-please-version
             public const string Copyright = "Patrik Lleshaj © 2026. MIT License.";
         }
 

--- a/src/TeamsPhoneManager.Presentation/MainWindow.axaml
+++ b/src/TeamsPhoneManager.Presentation/MainWindow.axaml
@@ -74,7 +74,8 @@
                                         Background="{DynamicResource TeamsPrimaryBrush}"
                                         BorderThickness="0"
                                         CornerRadius="5"
-                                        Padding="5,1"
+                                        Padding="6,2"
+                                        Margin="4,0,0,0"
                                         MinHeight="0"
                                         VerticalAlignment="Center"/>
                             </StackPanel>
@@ -199,6 +200,7 @@
                                     Command="{Binding ToggleSettingsCommand}"
                                     Width="34"
                                     Height="34"
+                                    Margin="4,0,0,0"
                                     Classes="IconOnly"
                                     AutomationProperties.Name="Settings"
                                     ToolTip.Tip="Settings">


### PR DESCRIPTION
## What this fixes

### Release Please version drift (root cause of phantom v4.0.0 PR)
`ConstantsService.cs` and `app.manifest` were not tracked as release-please extra-files, so the UI display version and Windows app manifest stayed stuck on 3.19.0 while actual releases were at 3.21.1. This also caused the in-app update check to show the wrong version in the top-left corner.

### UI spacing
- **UPDATE button** in sidebar header had no spacing between it and the version text / surrounding elements
- **Settings button** in sidebar footer was cramped against the connection status chips

## Changes

| File | Change |
|---|---|
| `release-please-config.json` | Added `ConstantsService.cs` and `app.manifest` as extra-files so release-please bumps all version files together |
| `ConstantsService.cs` | Bumped version from 3.19.0 → 3.21.1; added `x-release-please-version` marker |
| `app.manifest` | Bumped version from 3.19.0.0 → 3.21.1.0; added `x-release-please-version` marker |
| `MainWindow.axaml` | Added `Margin="4,0,0,0"` to UPDATE and Settings buttons for proper spacing |

## Verification
- ✅ Build succeeds (0 warnings, 0 errors)
- ✅ All 465 tests pass
- ✅ Closed erroneous v4.0.0 PR (#101) and deleted its branch