### PR TITLE
fix: anchor release-please to v3.21.1 to prevent phantom major bumps

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- x-release-please-version -->
   <assemblyIdentity 
-    version="3.21.2.0" <!-- x-release-please-version -->
+    version="3.21.2.0"
     name="TeamsPhoneManager"
     processorArchitecture="*"
     type="win32"/>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "teams-phonemanager",
       "include-component-in-tag": false,
       "draft": true,
+      "last-release-sha": "7b24ac70c519733a4ce23494d4f90de041b32ef8",
       "extra-files": [
         {
           "type": "generic",

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -6,8 +6,8 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>teams_phonemanager</RootNamespace>
     <Version>3.21.2</Version> <!-- x-release-please-version -->
-    <AssemblyVersion>3.21.2</AssemblyVersion> <!-- x-release-please-version -->
-    <FileVersion>3.21.2</FileVersion> <!-- x-release-please-version -->
+    <AssemblyVersion>3.21.2.0</AssemblyVersion> <!-- x-release-please-version -->
+    <FileVersion>3.21.2.0</FileVersion> <!-- x-release-please-version -->
     
     <!-- Publish Settings for Framework-Dependent Deployment -->
     <PublishSingleFile>false</PublishSingleFile>


### PR DESCRIPTION
## Problem
Release Please keeps creating erroneous v4.0.0 release PRs. The cause: the `simple` release type scans ALL conventional commits in repo history, and commit `0406e3d` has a `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters` footer from the v3.11.0 era.

## Fix
Add `last-release-sha` pointing to the `v3.21.1` tag commit. This tells release-please to only discover commits after that SHA, ignoring old history with breaking change footers that were already triaged into prior releases.

No more phantom major bumps.