### PR TITLE
fix: upgrade to release-please v5 and stop phantom v4.0.0 PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,23 +1,60 @@
 # Teams Phone Manager — Copilot Instructions
 
+## Architecture (Clean Architecture)
+
+4 layers under `src/`:
+- `TeamsPhoneManager.Domain` — framework-free (rules, value objects, constants, holiday computus, `LogLevel`, `IPhoneManagerVariables`/`IHolidayEntry`/`IDaySchedule` contracts)
+- `TeamsPhoneManager.Application` — ports (interfaces) + use cases (`ValidationService`)
+- `TeamsPhoneManager.Infrastructure` — PowerShell/MSAL adapters (only layer with `System.Management.Automation` and `Microsoft.Identity.Client`)
+- `TeamsPhoneManager.Presentation` — Avalonia/MVVM UI (depends only on Domain + Application)
+- `teams-phonemanager` (repo root exe) — composition root (DI, app.manifest, version, Modules content)
+
+**Dependency Rule**: enforced by `DependencyRuleTests` — forbidden inward deps fail the build.
+**ObservableObject models** = Presentation concern. **VM-first ViewLocator** (no service locator).
+
+## Frozen / Do Not Touch
+
+### Graph/PowerShell script builders & auth
+The `ScriptBuilders` in `src/TeamsPhoneManager.Infrastructure/ScriptBuilders/` and the auth flow (`MsalGraphAuthenticationService`, `PowerShellContextService`) are **off-limits** — do NOT change behavior or emitted text without asking. Structural changes (relocating, interfaces) OK if output stays byte-identical.
+
+### macOS signing cert
+The self-signed cert "Teams Phone Manager Self-Signed" (stable designated requirement `identifier "ch.realgar.teams-phonemanager" and certificate leaf = H"965282c9..."`) keeps MSAL keychain items / TCC grants across upgrades. **NEVER regenerate** — p12 at `~/.teams-phonemanager-signing/signing.p12`, also in repo secrets.
+
+## UI / Icons
+
+At 16px, dense FluentIcons glyphs (e.g. `PeopleTeam`, 3 figures) look thicker than sparse outlines. **Prefer simple outline glyphs** (1-2 subjects) for nav/buttons. Filled icons are OK on tinted badge circles (`.icon-badge` style), empty states, brand marks — solid glyphs can't have stroke-weight mismatches.
+
+**Brand**: T-Pad monogram (dial-pad dots, "T" at full white, side dots 38% opacity, diagonal gradient **#7B80EE → #45478F** + top sheen). Canonical source `assets/icon.svg`; all derived icons regenerate via `assets/generate-icons.py`; `BrandGradientBrush` in App.axaml.
+
+README screenshots at `docs/screenshots/` (2560×1496 = 1280×720 @2x + synthetic macOS title bar) regenerate via `ScreenshotGenerator.cs` (xunit `[Fact]`, only runs with `GENERATE_SCREENSHOTS=1`, uses Avalonia.Headless + real Skia, stubs services, validates frames before overwriting).
+
 ## Release Workflow
 
 - **Release-please-action**: Must use **v5** (SHA: `45996ed1f6d02564a971a2fa1b5860e934307cf7`), NOT v4. v4 is deprecated (Node 20) and causes issues.
 - **Config file**: `release-please-config.json`
 - **Manifest file**: `.release-please-manifest.json`
 - **Workflow file**: `.github/workflows/build.yml`
+- **Version source**: `teams-phonemanager.csproj` `<Version>` — also in `app.manifest` and `ConstantsService.cs`. Bump via `Scripts/bump-version.sh minor|patch|major`.
 
 ### Phantom v4.0.0 PR — root fix
 
-Release-please was repeatedly creating v4.0.0 release PRs because an old squashed commit (`0406e3d`, now rewritten as `8159da9`) contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters` in its commit body. Release-please scanned the full history and detected this as an un-released breaking change.
+Release-please repeatedly created v4.0.0 PRs because old squashed commit `0406e3d` contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters`. Fix: `git filter-branch` removed that line (rewritten to `8159da9`), all descendants also rewritten, force-pushed.
 
-**Fix applied**: The `BREAKING CHANGE` line was surgically removed from that commit's body via `git filter-branch` and force-pushed. The commit `0406e3d` was rewritten to `8159da9`. All downstream commits were also rewritten. No `last-release-sha` config hack is needed.
+**Do NOT reintroduce `BREAKING CHANGE:` footers unless you actually intend a major bump.**
 
-**Do NOT reintroduce `BREAKING CHANGE:` footers in commit messages unless you actually intend a major version bump.**
+### macOS signing & Homebrew delivery
+
+- Sign publish output BEFORE .app assembly (`Scripts/package-macos.sh`); bundle is never sealed (codesign rejects .NET managed-dll layout as nested code).
+- Homebrew cask (`realgarit/homebrew-tap`) needs `postflight` stripping `com.apple.quarantine` — Homebrew quarantines cask downloads and Gatekeeper SIGKILLs (exit 137) quarantined ad-hoc/self-signed binaries.
+- `bump-homebrew-cask` job pushes via `PAT_TOKEN`.
 
 ## CI
 
 - Build runs on Windows, macOS (x64 + arm64), Linux
-- Windows uses Inno Setup for installer packaging
-- macOS uses ad-hoc signing + .app bundle
-- **PR checkout**: Uses `github.event.pull_request.head.sha` instead of merge ref to avoid race condition (merge refs are deleted when PR merges, causing Windows runners to fail with "couldn't find remote ref")
+- Windows: Inno Setup installer; macOS: ad-hoc signed .app bundle; Linux: zip
+- **PR checkout**: `github.event.pull_request.head.sha` (not merge ref) to avoid race where merge ref is deleted before runner picks up the job
+- `dotnet test` skips screenshot gen unless `GENERATE_SCREENSHOTS=1`
+
+## Workflow Convention (PR workflow)
+
+Always: **branch → commit → push + open PR → CI green → merge (merge commit, not squash) → clean up ALL branches** (remote delete, local branches, stale worktrees). Always end a working session with a version bump (the bump IS the release trigger). Do NOT create tags manually — build.yml auto-creates them.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Teams Phone Manager — Copilot Instructions
+
+## Release Workflow
+
+- **Release-please-action**: Must use **v5** (SHA: `45996ed1f6d02564a971a2fa1b5860e934307cf7`), NOT v4. v4 is deprecated (Node 20) and causes issues.
+- **Config file**: `release-please-config.json`
+- **Manifest file**: `.release-please-manifest.json`
+- **Workflow file**: `.github/workflows/build.yml`
+
+### Phantom v4.0.0 PR — root fix
+
+Release-please was repeatedly creating v4.0.0 release PRs because an old squashed commit (`0406e3d`, now rewritten as `8159da9`) contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters` in its commit body. Release-please scanned the full history and detected this as an un-released breaking change.
+
+**Fix applied**: The `BREAKING CHANGE` line was surgically removed from that commit's body via `git filter-branch` and force-pushed. The commit `0406e3d` was rewritten to `8159da9`. All downstream commits were also rewritten. No `last-release-sha` config hack is needed.
+
+**Do NOT reintroduce `BREAKING CHANGE:` footers in commit messages unless you actually intend a major version bump.**
+
+## CI
+
+- Build runs on Windows, macOS (x64 + arm64), Linux
+- Windows uses Inno Setup for installer packaging
+- macOS uses ad-hoc signing + .app bundle
+- **PR checkout**: Uses `github.event.pull_request.head.sha` instead of merge ref to avoid race condition (merge refs are deleted when PR merges, causing Windows runners to fail with "couldn't find remote ref")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - name: Create or update release pull request
       id: release
-      uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5 # v4
+      uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         config-file: release-please-config.json
@@ -364,7 +364,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.validate_ref || github.ref }}
+        # For PR events, use the head SHA (not the merge ref) to avoid race
+        # where the merge ref is deleted before the runner picks up the job.
+        ref: ${{ inputs.validate_ref || github.event.pull_request.head.sha || github.ref }}
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+See `.github/copilot-instructions.md` for project context.


### PR DESCRIPTION
## Problem

Release-please v4 keeps creating a v4.0.0 release PR (#116) every time something merges to main. Root cause: an old squashed commit (`0406e3d`) contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters` in its commit body. Release-please scanned the full history and detected this as an un-released breaking change.

Additionally, a CI race condition caused the Windows validation to fail on run #29282630253: PR #117's merge ref was deleted before the Windows runner picked up the job.

## Changes

1. **Root fix — removed BREAKING CHANGE from commit history** — Used `git filter-branch` to surgically remove the `BREAKING CHANGE:` line from the old commit body. The commit was rewritten from `0406e3d` → `8159da9`, all downstream commits rewritten. Force-pushed.

2. **Upgrade to release-please-action v5** — from `v4` (SHA `8b8fd2c`) to `v5` (SHA `45996ed`). v5 runs on Node 24 (GitHub Actions deprecated Node 20).

3. **CI race fix** — Use `github.event.pull_request.head.sha` instead of `github.ref` for PR validation checkouts. The merge ref `refs/pull/N/merge` is deleted as soon as a PR merges.

4. **`.github/copilot-instructions.md`** — Persistent agent context with release-please and CI knowledge, so future sessions know about the v4 fix.