### PR TITLE
fix: prevent phantom v4.0.0 by anchoring release-please with last-release-sha

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,9 +36,11 @@ README screenshots at `docs/screenshots/` (2560×1496 = 1280×720 @2x + syntheti
 - **Workflow file**: `.github/workflows/build.yml`
 - **Version source**: `teams-phonemanager.csproj` `<Version>` — also in `app.manifest` and `ConstantsService.cs`. Bump via `Scripts/bump-version.sh minor|patch|major`.
 
-### Phantom v4.0.0 PR — root fix
+### Phantom v4.0.0 PR — root fix & prevention
 
-Release-please repeatedly created v4.0.0 PRs because old squashed commit `0406e3d` contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters`. Fix: `git filter-branch` removed that line (rewritten to `8159da9`), all descendants also rewritten, force-pushed.
+Release-please repeatedly created v4.0.0 PRs because old squashed commit `0406e3d` contained `BREAKING CHANGE: ViewModel constructors now require ISharedStateService and IDialogService parameters`. 
+
+**Permanent fix**: `last-release-sha` in `release-please-config.json` anchors release-please to only scan commits after the specified SHA. The value points to the v3.21.5 release commit — any BREAKING CHANGE footers before it are ignored.
 
 **Do NOT reintroduce `BREAKING CHANGE:` footers unless you actually intend a major bump.**
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "teams-phonemanager",
       "include-component-in-tag": false,
       "draft": true,
+      "last-release-sha": "8eb007b104609408e270262ac9dbaafa72b0d113",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Problem

Release-please keeps creating phantom v4.0.0 release PRs because an old squashed commit (`0406e3d`) contains a `BREAKING CHANGE:` footer in its body. Even after removing it from git history with filter-branch, the old commit object still exists in GitHub's object store and release-please scans all reachable history.

## Fix

Adds `last-release-sha` to `release-please-config.json` pointing to the current v3.21.5 release HEAD. This is the officially documented way to tell release-please: "stop scanning before this point." Any BREAKING CHANGE footers before this SHA will never trigger a major version bump.

## Why this approach

- **One line** in existing config — no git history rewriting, no tag manipulation
- **Permanent** — survives all future merges
- **Documented feature** of release-please, not a hack
- Previous attempts (git filter-branch, release-as, last-release-sha removals) all failed because the old commit was still reachable from old tags on GitHub