### PR TITLE
fix: move last-release-sha to root level where release-please actually reads it

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "8eb007b104609408e270262ac9dbaafa72b0d113",
   "packages": {
     ".": {
       "release-type": "simple",
       "package-name": "teams-phonemanager",
       "include-component-in-tag": false,
       "draft": true,
-      "last-release-sha": "8eb007b104609408e270262ac9dbaafa72b0d113",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Problem

The phantom v4.0.0 release PR keeps being created because the `last-release-sha` config option was placed inside the `packages["."]` entry in `release-please-config.json`. 

The release-please source code (`src/manifest.ts:parseConfig`) only reads `last-release-sha` from the **root level** of the config JSON — it is not read from individual package entries. This means the config we thought was working was silently ignored.

## Fix

- Move `last-release-sha: "8eb007b..."` from inside `packages["."]` to the root of `release-please-config.json`
- This tells release-please to stop its commit iterator at SHA `8eb007b` (v3.21.5 release), ensuring the old BREAKING CHANGE footer in commit `0406e3d` is never included in commit analysis

## Verification

- Source: https://github.com/googleapis/release-please/blob/main/src/manifest.ts — `parseConfig` function reads `config['last-release-sha']` (root level), not `config.packages[...]['last-release-sha']`
- Schema docs confirm: "only applicable at top-level config"
- After merging, release-please will properly cap its commit scan at `8eb007b`, permanently preventing the v4.0.0 phantom PR