### PR TITLE
fix: add force-tag-creation to prevent duplicate release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "package-name": "teams-phonemanager",
       "include-component-in-tag": false,
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Problem

With `draft: true` (which we need so we can upload build assets before publishing), GitHub does **not** create a Git tag until the draft is manually published. When release-please runs after a merge to open the next release PR, it can't find the tag for the just-released commit → it re-scans old commits → creates a duplicate PR.

This is exactly what happened with PR #127 duplicating #126.

## Solution

Add `force-tag-creation: true` — the official release-please option designed for this exact scenario. From the schema docs:

> *"Force the creation of a Git tag for the release. This is particularly useful when `draft` is enabled, because GitHub does not create a Git tag for draft releases until they are published. This 'lazy tag creation' causes release-please to fail to find the previous release, potentially generating incorrect changelogs."*

With this, the Git tag is created immediately even for draft releases, so release-please always finds it and correctly skips already-released commits.

## Best practice validation

✅ Per the [release-please schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json): `force-tag-creation` exists specifically for this use case  
✅ We keep `draft: true` — release stays hidden until CI finishes uploading assets  
✅ No more duplicate release PRs