### PR TITLE
fix: sidebar brand and footer spacing

### DIFF
--- a/src/TeamsPhoneManager.Presentation/MainWindow.axaml
+++ b/src/TeamsPhoneManager.Presentation/MainWindow.axaml
@@ -42,24 +42,26 @@
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="12" Margin="16,18,16,10">
                         <Border Width="38" Height="38"
                                 CornerRadius="9"
-                                BoxShadow="0 4 14 0 #405B5FC7">
+                                BoxShadow="0 4 14 0 #405B5FC7"
+                                VerticalAlignment="Top"
+                                Margin="0,1,0,0">
                             <!-- The actual app icon, so branding matches the dock/taskbar/installer.
                                  CornerRadius mirrors the icon's own corner radius (38 * 230/1024). -->
                             <Image Source="avares://TeamsPhoneManager.Presentation/Resources/app-icon.png"
                                    Width="38" Height="38"/>
                         </Border>
-                        <StackPanel VerticalAlignment="Center" Spacing="1">
+                        <StackPanel VerticalAlignment="Center" Spacing="2">
                             <TextBlock Text="Teams Phone"
                                        FontFamily="{StaticResource DisplayFontFamily}"
                                        FontSize="15"
                                        FontWeight="Bold"
                                        LetterSpacing="-0.2"/>
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <TextBlock Text="Manager"
-                                           FontFamily="{StaticResource DisplayFontFamily}"
-                                           FontSize="11"
-                                           Foreground="{DynamicResource TeamsPrimaryBrush}"
-                                           LetterSpacing="2.2"/>
+                            <TextBlock Text="Manager"
+                                       FontFamily="{StaticResource DisplayFontFamily}"
+                                       FontSize="11"
+                                       Foreground="{DynamicResource TeamsPrimaryBrush}"
+                                       LetterSpacing="2.2"/>
+                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0">
                                 <TextBlock Text="{Binding Version}"
                                            FontSize="10"
                                            VerticalAlignment="Center"
@@ -68,15 +70,14 @@
                                         Command="{Binding ShowUpdateBannerCommand}"
                                         IsVisible="{Binding IsUpdateAvailable}"
                                         ToolTip.Tip="{Binding UpdateBannerMessage}"
-                                        FontSize="8"
+                                        FontSize="9"
                                         FontWeight="SemiBold"
                                         Foreground="White"
                                         Background="{DynamicResource TeamsPrimaryBrush}"
                                         BorderThickness="0"
-                                        CornerRadius="5"
-                                        Padding="6,2"
-                                        Margin="4,0,0,0"
-                                        MinHeight="0"
+                                        CornerRadius="4"
+                                        Padding="7,1"
+                                        MinHeight="16"
                                         VerticalAlignment="Center"/>
                             </StackPanel>
                         </StackPanel>
@@ -172,17 +173,17 @@
                     </ScrollViewer>
 
                     <!-- Sidebar footer: connection state + settings -->
-                    <StackPanel Grid.Row="2" Margin="16,10,16,14" Spacing="10">
-                        <Border Height="1" Background="{DynamicResource HairlineBrush}" Margin="-6,0"/>
+                    <StackPanel Grid.Row="2" Margin="14,10,14,14" Spacing="10">
+                        <Border Height="1" Background="{DynamicResource HairlineBrush}" Margin="-4,0"/>
                         <Grid ColumnDefinitions="*,Auto" ToolTip.Tip="{Binding ConnectionStatusText}">
-                            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6">
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
                                 <Border Classes="chip" Classes.ok="{Binding IsTeamsConnected}">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
                                         <Ellipse Classes="status-dot" Fill="{DynamicResource StatusOnBrush}"
                                                  IsVisible="{Binding IsTeamsConnected}"/>
                                         <Ellipse Classes="status-dot" Fill="{DynamicResource StatusOffBrush}"
                                                  IsVisible="{Binding !IsTeamsConnected}"/>
-                                        <TextBlock Text="Teams"/>
+                                        <TextBlock Text="Teams" FontSize="11"/>
                                     </StackPanel>
                                 </Border>
                                 <Border Classes="chip" Classes.ok="{Binding IsGraphConnected}">
@@ -191,20 +192,20 @@
                                                  IsVisible="{Binding IsGraphConnected}"/>
                                         <Ellipse Classes="status-dot" Fill="{DynamicResource StatusOffBrush}"
                                                  IsVisible="{Binding !IsGraphConnected}"/>
-                                        <TextBlock Text="Graph"/>
+                                        <TextBlock Text="Graph" FontSize="11"/>
                                     </StackPanel>
                                 </Border>
                             </StackPanel>
                             <Button x:Name="SettingsButton"
                                     Grid.Column="1"
                                     Command="{Binding ToggleSettingsCommand}"
-                                    Width="34"
-                                    Height="34"
-                                    Margin="4,0,0,0"
+                                    Width="32"
+                                    Height="32"
+                                    Margin="6,0,0,0"
                                     Classes="IconOnly"
                                     AutomationProperties.Name="Settings"
                                     ToolTip.Tip="Settings">
-                                <fi:SymbolIcon Symbol="Settings"/>
+                                <fi:SymbolIcon Symbol="Settings" FontSize="16"/>
                             </Button>
                         </Grid>
                     </StackPanel>


### PR DESCRIPTION
## Problem

The sidebar brand area (version + UPDATE button) and footer (status chips + Settings gear) were overflow-ing on macOS due to cramped spacing in a 244px sidebar.

### Brand area (before)
All in one horizontal line: `Manager` (11px, letter-spaced 2.2) + `v3.21.6` (10px) + `UPDATE` button (8px) — overflowing when the text renders wider on macOS.

### Footer (before)
Two status chips (`Teams` and `Graph`) at 6px gap + 34x34 Settings button at 4px margin — no breathing room.

## Changes

**Brand area:**
- `Teams Phone`, `Manager`, and `Version + UPDATE` are now on three separate vertical lines
- Clean 2px spacing between lines
- UPDATE button font bumped to 9px with better proportions (7,1 padding, 16px min-height)
- App icon aligned to first text line

**Footer:**
- Chip gap increased 6px → 8px
- Settings button reduced 34x34 → 32x32 with 16px icon (better proportion vs chips)
- Margin gap 4px → 6px