### PR TITLE
fix: block wizard advancement past a failed step

### DIFF
--- a/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
@@ -38,7 +38,7 @@ namespace teams_phonemanager.ViewModels
         [ObservableProperty]
         private ObservableCollection<WizardStepInfo> _steps = new();
 
-        public bool CanGoNext => CurrentStep < TotalSteps - 1;
+        public bool CanGoNext => CurrentStep < TotalSteps - 1 && !StepFailed;
         public bool CanGoPrevious => CurrentStep > 0;
         public bool CanExecuteStep => !IsBusy && !StepCompleted;
 
@@ -94,6 +94,7 @@ namespace teams_phonemanager.ViewModels
                 OnPropertyChanged(nameof(CanGoNext));
                 OnPropertyChanged(nameof(CanGoPrevious));
                 OnPropertyChanged(nameof(CanExecuteStep));
+                GoToNextStepCommand.NotifyCanExecuteChanged();
             }
         }
 
@@ -243,10 +244,10 @@ namespace teams_phonemanager.ViewModels
             OnPropertyChanged(nameof(CanExecuteStep));
         }
 
-        [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanGoNext))]
         private void GoToNextStep()
         {
-            if (CurrentStep < TotalSteps - 1)
+            if (CurrentStep < TotalSteps - 1 && !StepFailed)
             {
                 CurrentStep++;
                 UpdateCurrentStep();
@@ -308,6 +309,12 @@ namespace teams_phonemanager.ViewModels
         partial void OnCurrentStepChanged(int value)
         {
             UpdateCurrentStep();
+        }
+
+        partial void OnStepFailedChanged(bool value)
+        {
+            OnPropertyChanged(nameof(CanGoNext));
+            GoToNextStepCommand.NotifyCanExecuteChanged();
         }
     }
 

--- a/teams-phonemanager.Tests/WizardViewModelTests.cs
+++ b/teams-phonemanager.Tests/WizardViewModelTests.cs
@@ -180,23 +180,48 @@ namespace teams_phonemanager.Tests
         }
 
         [Fact]
-        public void GoToNextStepCommand_AfterStepFailure_CurrentImplementationDoesNotBlockAdvancement()
+        public async Task GoToNextStepCommand_AfterStepFailure_CannotAdvancePastFailedStep()
         {
-            // NOTE: this documents the ViewModel's *actual* current behavior, which is a gap against the
-            // acceptance criterion "cannot advance past a failed step". CanGoNext (bound to the Next
-            // button's IsEnabled in WizardView.axaml) is defined purely as `CurrentStep < TotalSteps - 1`
-            // and does not consult StepFailed/Steps[CurrentStep].IsFailed, and GoToNextStep()'s body has
-            // the same bounds-only guard. So today, once a step fails, the Next command remains enabled
-            // and calling it does move the wizard forward. Flagged for the orchestrator rather than
-            // silently "fixed" here, since gating GoToNextStep on step failure is a product decision.
+            // Acceptance criterion: cannot advance past a failed step. CanGoNext (bound to the Next
+            // button's IsEnabled in WizardView.axaml) consults StepFailed/Steps[CurrentStep].IsFailed
+            // in addition to the bounds check, and GoToNextStep() guards identically, so once a step
+            // fails the Next command is disabled and calling it does not move the wizard forward.
             var harness = new ViewModelTestHarness();
+            harness.PowerShellCommandService.Setup(c => c.GetCreateM365GroupCommand(It.IsAny<string>())).Returns("New-CsGroup ...");
             var vm = CreateViewModel(harness);
             vm.GoToNextStepCommand.Execute(null); // step 1
             harness.SetExecutionResult("ERROR: boom", hadErrors: true);
+            await vm.ExecuteCurrentStepCommand.ExecuteAsync(null);
+            Assert.True(vm.StepFailed);
 
-            var canExecuteBeforeAdvance = vm.GoToNextStepCommand.CanExecute(null);
+            var canExecuteAfterFailure = vm.GoToNextStepCommand.CanExecute(null);
+            Assert.False(canExecuteAfterFailure);
 
-            Assert.True(canExecuteBeforeAdvance);
+            vm.GoToNextStepCommand.Execute(null);
+
+            Assert.Equal(1, vm.CurrentStep);
+        }
+
+        [Fact]
+        public async Task GoToNextStepCommand_AfterFailureIsRetriedSuccessfully_CanAdvanceAgain()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.PowerShellCommandService.Setup(c => c.GetCreateM365GroupCommand(It.IsAny<string>())).Returns("New-CsGroup ...");
+            var vm = CreateViewModel(harness);
+            vm.GoToNextStepCommand.Execute(null); // step 1
+            harness.SetExecutionResult("ERROR: boom", hadErrors: true);
+            await vm.ExecuteCurrentStepCommand.ExecuteAsync(null);
+            Assert.False(vm.GoToNextStepCommand.CanExecute(null));
+
+            vm.RetryStepCommand.Execute(null);
+            harness.SetExecutionResult("SUCCESS: group created");
+            await vm.ExecuteCurrentStepCommand.ExecuteAsync(null);
+
+            Assert.True(vm.GoToNextStepCommand.CanExecute(null));
+
+            vm.GoToNextStepCommand.Execute(null);
+
+            Assert.Equal(2, vm.CurrentStep);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- `CanGoNext` now returns false once the current step has failed (`StepFailed`), in addition to the existing bounds check.
- `GoToNextStep()` guards identically, so calling the command while a step is failed is a no-op.
- `GoToNextStepCommand` now has `CanExecute = nameof(CanGoNext)`, and `NotifyCanExecuteChanged()` is called whenever `StepFailed` changes or the current step updates, so the Next button disables immediately on failure and re-enables after a successful retry.

## Test plan
- [x] Replaced the pinned gap-documenting test with `GoToNextStepCommand_AfterStepFailure_CannotAdvancePastFailedStep`, asserting `CanGoNext`/`CanExecute` is false and `GoToNextStep()` does not advance after a failure.
- [x] Added `GoToNextStepCommand_AfterFailureIsRetriedSuccessfully_CanAdvanceAgain`, asserting advancement works again after `RetryStep` + a successful re-execution.
- [x] Full suite: `dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj` — 466 passed, 0 failed.

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)