### PR TITLE
fix: strip UTF-8 BOM from CSV headers in bulk operations

### DIFF
--- a/src/TeamsPhoneManager.Presentation/Services/ScriptBuilders/BulkOperationsScriptBuilder.cs
+++ b/src/TeamsPhoneManager.Presentation/Services/ScriptBuilders/BulkOperationsScriptBuilder.cs
@@ -63,6 +63,15 @@ namespace teams_phonemanager.Services.ScriptBuilders
         public List<PhoneManagerVariables> ParseCsv(string csvContent)
         {
             var results = new List<PhoneManagerVariables>();
+
+            // Strip a leading UTF-8 BOM (U+FEFF) so it doesn't get glued onto the first header
+            // token (e.g. "Customer" becoming "﻿Customer"), which would otherwise break the
+            // case-insensitive header lookup and silently drop the first column's values.
+            if (csvContent.Length > 0 && csvContent[0] == '﻿')
+            {
+                csvContent = csvContent.Substring(1);
+            }
+
             var lines = csvContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             if (lines.Length < 2)

--- a/teams-phonemanager.Tests/BulkOperationsViewModelTests.cs
+++ b/teams-phonemanager.Tests/BulkOperationsViewModelTests.cs
@@ -49,12 +49,12 @@ namespace teams_phonemanager.Tests
         // ── CSV parsing edge cases ──────────────────────────────────────────
 
         [Fact]
-        public void ParseCsv_Utf8Bom_DoesNotThrow_ButBreaksFirstHeaderMatch()
+        public void ParseCsv_Utf8Bom_StripsBom_FirstHeaderMatchesCorrectly()
         {
-            // A UTF-8 BOM prefixed onto the header line becomes part of the first header token
-            // ("﻿Customer"), so BulkOperationsScriptBuilder.GetField's lookup for "Customer"
-            // misses and that column comes back empty. This documents the real current behavior —
-            // parsing does not throw and the row is still added, but the first column is dropped.
+            // A UTF-8 BOM prefixed onto the header line must not become part of the first header
+            // token ("﻿Customer"), which would otherwise make BulkOperationsScriptBuilder.GetField's
+            // lookup for "Customer" miss and silently drop that column. The BOM should be stripped
+            // before header parsing so the first column matches and parses normally.
             var harness = new ViewModelTestHarness();
             var vm = CreateViewModel(harness);
             vm.CsvContent = "﻿" + TemplateHeader + "\n" + TemplateDataRow;
@@ -63,7 +63,7 @@ namespace teams_phonemanager.Tests
 
             Assert.Single(vm.ParsedEntries);
             var entry = vm.ParsedEntries[0];
-            Assert.Equal(string.Empty, entry.Customer);
+            Assert.Equal("contoso", entry.Customer);
             Assert.Equal("hauptnummer", entry.GroupName);
             Assert.Equal("+41441234567", entry.PhoneNumber);
             Assert.Equal("de-DE", entry.Language);


### PR DESCRIPTION
Fixes #86

## Bug
`BulkOperationsScriptBuilder.ParseCsv` split the CSV content on `\n` and parsed the first line as headers without stripping a leading UTF-8 BOM (U+FEFF). When CSV content starts with a BOM (as many editors and export tools produce), the first header token becomes `"﻿Customer"` instead of `"Customer"`. Because header lookups use a case-insensitive `OrdinalIgnoreCase` dictionary keyed on exact header text, the BOM-prefixed key never matches `"Customer"`, so the first column's value is silently dropped for every row during bulk operations.

## Fix
Strip a leading BOM character from `csvContent` before splitting into lines/headers in `ParseCsv`. No other behavior (script templates, PowerShell command generation, MSAL/Graph auth) was touched.

## Testing
- Updated the existing test `ParseCsv_Utf8Bom_...` in `teams-phonemanager.Tests/BulkOperationsViewModelTests.cs` (previously named `..._DoesNotThrow_ButBreaksFirstHeaderMatch`, documenting the bug) to assert the fixed behavior: the first column (`Customer`) now parses correctly when the CSV is BOM-prefixed.
- Confirmed the updated test fails against the pre-fix code (TDD red step), then passes after the fix.
- Ran the full test suite: `dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj` — 465 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)