### PR TITLE
feat: pin bundled module versions and show them in About

### DIFF
--- a/.github/workflows/module-compatibility.yml
+++ b/.github/workflows/module-compatibility.yml
@@ -1,0 +1,119 @@
+name: Module Compatibility Check
+
+# Weekly best-effort check for newer PowerShell Gallery releases of the bundled modules
+# (see Scripts/module-versions.json). Never triggers on push/pull_request: it only runs on
+# its own schedule (plus manual dispatch) so it can't slow down or block normal CI.
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-module-versions:
+    name: Check for newer module versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Query PowerShell Gallery for latest versions
+        id: query
+        run: |
+          set -euo pipefail
+          VERSIONS_FILE="Scripts/module-versions.json"
+          HAS_UPDATE=false
+          SUMMARY_FILE="$RUNNER_TEMP/version-summary.md"
+          : > "$SUMMARY_FILE"
+
+          NAMES=$(jq -r '.modules[].name' "$VERSIONS_FILE")
+          for NAME in $NAMES; do
+            CURRENT=$(jq -r --arg name "$NAME" '.modules[] | select(.name == $name) | .version' "$VERSIONS_FILE")
+
+            # Best-effort: PowerShell Gallery v2 OData feed, latest version for the module id.
+            LATEST=$(curl -fsSL "https://www.powershellgallery.com/api/v2/Packages()?\$filter=Id%20eq%20%27${NAME}%27%20and%20IsLatestVersion&\$orderby=Version%20desc&\$top=1" \
+              | grep -o '<d:Version>[^<]*</d:Version>' \
+              | head -1 \
+              | sed -e 's/<d:Version>//' -e 's/<\/d:Version>//' || true)
+
+            if [[ -z "$LATEST" ]]; then
+              echo "::warning::Could not determine latest version for $NAME, skipping."
+              continue
+            fi
+
+            echo "$NAME: current=$CURRENT latest=$LATEST"
+            if [[ "$LATEST" != "$CURRENT" ]]; then
+              HAS_UPDATE=true
+              echo "- **$NAME**: \`$CURRENT\` → \`$LATEST\` ([changelog](https://www.powershellgallery.com/packages/${NAME}/${LATEST}))" >> "$SUMMARY_FILE"
+              jq --arg name "$NAME" --arg version "$LATEST" \
+                '(.modules[] | select(.name == $name) | .version) = $version' \
+                "$VERSIONS_FILE" > "$VERSIONS_FILE.tmp"
+              mv "$VERSIONS_FILE.tmp" "$VERSIONS_FILE"
+            fi
+          done
+
+          echo "has_update=$HAS_UPDATE" >> "$GITHUB_OUTPUT"
+          echo "summary_file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Build and test with updated pins
+        if: steps.query.outputs.has_update == 'true'
+        id: build
+        continue-on-error: true
+        run: |
+          dotnet restore TeamsPhoneManager.slnx
+          dotnet build TeamsPhoneManager.slnx --configuration Release --no-restore
+          dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj --configuration Release --no-build 2>&1 | tee "$RUNNER_TEMP/build-output.log"
+
+      - name: Open pull request with bumped versions
+        if: steps.query.outputs.has_update == 'true' && steps.build.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="module-compatibility/$(date +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Scripts/module-versions.json
+          git commit -m "chore: bump bundled PowerShell module versions"
+          git push origin "$BRANCH"
+          gh pr create --title "chore: bump bundled PowerShell module versions" \
+            --body "$(cat <<EOF
+          Weekly module compatibility check found newer versions on the PowerShell Gallery.
+
+          $(cat "${{ steps.query.outputs.summary_file }}")
+
+          Build and tests passed against the updated pins. Review the changelog links above before merging.
+          EOF
+          )"
+
+      - name: Open issue on build/test failure
+        if: steps.query.outputs.has_update == 'true' && steps.build.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh issue create --title "Module compatibility check: build/test failure with newer module versions" \
+            --body "$(cat <<EOF
+          The weekly module compatibility check found newer versions of one or more bundled
+          PowerShell modules, but the build/test run against the updated pins failed. No PR
+          was opened; the pin file was left unchanged.
+
+          $(cat "${{ steps.query.outputs.summary_file }}")
+
+          Build/test output:
+
+          \`\`\`
+          $(tail -c 20000 "$RUNNER_TEMP/build-output.log" 2>/dev/null || echo "No output captured.")
+          \`\`\`
+          EOF
+          )"

--- a/Program.cs
+++ b/Program.cs
@@ -50,6 +50,7 @@ class Program
         services.AddSingleton<ISharedStateService, SharedStateService>();
         services.AddSingleton<IUpdateCheckService, GitHubUpdateCheckService>();
         services.AddSingleton<IUpdateInstallerService, GitHubUpdateInstallerService>();
+        services.AddSingleton<IBundledModuleVersionService, BundledModuleVersionService>();
         
         // UI Services (singleton - manages UI state)
         services.AddSingleton<IDialogService, DialogService>();

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ Built with Avalonia, CommunityToolkit.Mvvm, Microsoft.PowerShell.SDK, and MSAL.
 Releases use Conventional Commit PR titles. Release Please opens the version PR;
 merging it creates the tag, release notes, platform packages, and Homebrew update.
 
+### Bundled PowerShell modules
+
+The app ships with pinned versions of MicrosoftTeams and the Microsoft.Graph.* modules it
+needs, declared in [`Scripts/module-versions.json`](Scripts/module-versions.json). CI reads
+this file at build time (`Scripts/download-modules.ps1` / `.sh`) to download exactly those
+versions into `Modules/`, which are bundled into every published build. The pinned versions
+are also surfaced in the app itself, in **Settings → About**, alongside the bundled
+PowerShell SDK version.
+
+The [`module-compatibility.yml`](.github/workflows/module-compatibility.yml) workflow runs
+weekly (and on manual dispatch) to check the PowerShell Gallery for newer releases of the
+pinned modules. When a newer version is found, it bumps `module-versions.json`, builds and
+tests against the update, and opens a pull request if that succeeds (or an issue with the
+failure details if it doesn't) — the pins are never bumped automatically without a passing
+build.
+
+To bump a pinned version manually: edit `Scripts/module-versions.json` and either run
+`Scripts/download-modules.ps1` / `.sh` locally to re-download `Modules/`, or just push the
+change — the next CI build downloads the updated versions automatically.
+
 ## License
 
 MIT © 2026 Patrik Lleshaj. See [LICENSE](LICENSE).

--- a/Scripts/download-modules.ps1
+++ b/Scripts/download-modules.ps1
@@ -12,14 +12,23 @@ if (!(Test-Path $modulesDir)) {
     New-Item -Path $modulesDir -ItemType Directory -Force | Out-Null
 }
 
+# Pinned module versions (see Scripts/module-versions.json)
+$versionsFile = Join-Path $PSScriptRoot 'module-versions.json'
+$versions = Get-Content $versionsFile -Raw | ConvertFrom-Json
+$moduleVersions = @{}
+foreach ($entry in $versions.modules) {
+    $moduleVersions[$entry.name] = $entry.version
+}
+
 # MicrosoftTeams module (single module)
 Write-Host "Downloading MicrosoftTeams module..."
 try {
     $nupkg = Join-Path $modulesDir 'MicrosoftTeams.nupkg'
     $zip = Join-Path $modulesDir 'MicrosoftTeams.zip'
     $destination = Join-Path $modulesDir 'MicrosoftTeams'
+    $teamsVersion = $moduleVersions['MicrosoftTeams']
 
-    Invoke-WebRequest -Uri "https://www.powershellgallery.com/api/v2/package/MicrosoftTeams" -OutFile $nupkg
+    Invoke-WebRequest -Uri "https://www.powershellgallery.com/api/v2/package/MicrosoftTeams/$teamsVersion" -OutFile $nupkg
     Write-Host "MicrosoftTeams downloaded successfully"
     
     # Extract the module
@@ -51,8 +60,9 @@ foreach ($module in $coreGraphModules) {
         $nupkg = Join-Path $modulesDir "$module.nupkg"
         $zip = Join-Path $modulesDir "$module.zip"
         $destination = Join-Path $modulesDir $module
+        $moduleVersion = $moduleVersions[$module]
 
-        Invoke-WebRequest -Uri "https://www.powershellgallery.com/api/v2/package/$module" -OutFile $nupkg
+        Invoke-WebRequest -Uri "https://www.powershellgallery.com/api/v2/package/$module/$moduleVersion" -OutFile $nupkg
         Write-Host "$module downloaded successfully"
         
         # Extract the module

--- a/Scripts/download-modules.sh
+++ b/Scripts/download-modules.sh
@@ -14,13 +14,17 @@ MODULES_DIR="$REPO_ROOT/Modules"
 # Create Modules directory if it doesn't exist
 mkdir -p "$MODULES_DIR"
 
+# Pinned module versions (see Scripts/module-versions.json)
+VERSIONS_FILE="$SCRIPT_DIR/module-versions.json"
+TEAMS_VERSION="$(jq -r '.modules[] | select(.name == "MicrosoftTeams") | .version' "$VERSIONS_FILE")"
+
 # MicrosoftTeams module (single module)
 echo "Downloading MicrosoftTeams module..."
 TEAMS_NUPKG="$MODULES_DIR/MicrosoftTeams.nupkg"
 TEAMS_ZIP="$MODULES_DIR/MicrosoftTeams.zip"
 TEAMS_DEST="$MODULES_DIR/MicrosoftTeams"
 
-curl -L -o "$TEAMS_NUPKG" "https://www.powershellgallery.com/api/v2/package/MicrosoftTeams"
+curl -L -o "$TEAMS_NUPKG" "https://www.powershellgallery.com/api/v2/package/MicrosoftTeams/$TEAMS_VERSION"
 echo "MicrosoftTeams downloaded successfully"
 
 # Extract the module
@@ -46,8 +50,9 @@ for module in "${CORE_GRAPH_MODULES[@]}"; do
     NUPKG="$MODULES_DIR/${module}.nupkg"
     ZIP="$MODULES_DIR/${module}.zip"
     DEST="$MODULES_DIR/$module"
-    
-    curl -L -o "$NUPKG" "https://www.powershellgallery.com/api/v2/package/$module"
+    MODULE_VERSION="$(jq -r --arg name "$module" '.modules[] | select(.name == $name) | .version' "$VERSIONS_FILE")"
+
+    curl -L -o "$NUPKG" "https://www.powershellgallery.com/api/v2/package/$module/$MODULE_VERSION"
     echo "$module downloaded successfully"
     
     # Extract the module

--- a/Scripts/module-versions.json
+++ b/Scripts/module-versions.json
@@ -1,11 +1,11 @@
 {
   "modules": [
-    { "name": "MicrosoftTeams", "version": "6.9.0" },
-    { "name": "Microsoft.Graph.Authentication", "version": "2.25.0" },
-    { "name": "Microsoft.Graph.Users", "version": "2.25.0" },
-    { "name": "Microsoft.Graph.Users.Actions", "version": "2.25.0" },
-    { "name": "Microsoft.Graph.Groups", "version": "2.25.0" },
-    { "name": "Microsoft.Graph.Identity.DirectoryManagement", "version": "2.25.0" }
+    { "name": "MicrosoftTeams", "version": "7.8.0" },
+    { "name": "Microsoft.Graph.Authentication", "version": "2.38.1" },
+    { "name": "Microsoft.Graph.Users", "version": "2.38.1" },
+    { "name": "Microsoft.Graph.Users.Actions", "version": "2.38.1" },
+    { "name": "Microsoft.Graph.Groups", "version": "2.38.1" },
+    { "name": "Microsoft.Graph.Identity.DirectoryManagement", "version": "2.38.1" }
   ],
   "powerShellSdkVersion": "7.6.0"
 }

--- a/Scripts/module-versions.json
+++ b/Scripts/module-versions.json
@@ -1,0 +1,11 @@
+{
+  "modules": [
+    { "name": "MicrosoftTeams", "version": "6.9.0" },
+    { "name": "Microsoft.Graph.Authentication", "version": "2.25.0" },
+    { "name": "Microsoft.Graph.Users", "version": "2.25.0" },
+    { "name": "Microsoft.Graph.Users.Actions", "version": "2.25.0" },
+    { "name": "Microsoft.Graph.Groups", "version": "2.25.0" },
+    { "name": "Microsoft.Graph.Identity.DirectoryManagement", "version": "2.25.0" }
+  ],
+  "powerShellSdkVersion": "7.6.0"
+}

--- a/src/TeamsPhoneManager.Application/Interfaces/IBundledModuleVersionService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IBundledModuleVersionService.cs
@@ -1,0 +1,20 @@
+namespace teams_phonemanager.Services.Interfaces;
+
+/// <summary>
+/// Port for reading the pinned versions of the PowerShell modules bundled with the app
+/// (see Scripts/module-versions.json), for display in the Settings/About panel.
+/// </summary>
+public interface IBundledModuleVersionService
+{
+    /// <summary>Pinned MicrosoftTeams module version, or "Unknown" if it cannot be read.</summary>
+    string TeamsModuleVersion { get; }
+
+    /// <summary>
+    /// Pinned Microsoft.Graph module version, representative of all bundled Microsoft.Graph.*
+    /// modules (they are versioned together), or "Unknown" if it cannot be read.
+    /// </summary>
+    string GraphModuleVersion { get; }
+
+    /// <summary>Bundled PowerShell SDK version, or "Unknown" if it cannot be read.</summary>
+    string PowerShellSdkVersion { get; }
+}

--- a/src/TeamsPhoneManager.Infrastructure/BundledModuleVersionService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/BundledModuleVersionService.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using System.Text.Json;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Services;
+
+/// <summary>
+/// Reads the pinned PowerShell module versions bundled with the app from
+/// Scripts/module-versions.json (copied to the output directory alongside the app; see
+/// teams-phonemanager.csproj). Fails silently: any missing/malformed file yields "Unknown"
+/// values rather than throwing, so the Settings/About panel never crashes.
+/// </summary>
+public sealed class BundledModuleVersionService : IBundledModuleVersionService
+{
+    private const string UnknownVersion = "Unknown";
+    private const string VersionsFileName = "Scripts/module-versions.json";
+    private const string GraphModulePrefix = "Microsoft.Graph";
+
+    public string TeamsModuleVersion { get; }
+    public string GraphModuleVersion { get; }
+    public string PowerShellSdkVersion { get; }
+
+    /// <summary>Used by DI: reads Scripts/module-versions.json next to the running app.</summary>
+    public BundledModuleVersionService(ILoggingService? loggingService = null)
+        : this(Path.Combine(AppContext.BaseDirectory, VersionsFileName), loggingService)
+    {
+    }
+
+    /// <summary>Test seam: reads the manifest from an explicit path instead of the app's output directory.</summary>
+    public BundledModuleVersionService(string versionsFilePath, ILoggingService? loggingService = null)
+    {
+        var (teamsVersion, graphVersion, sdkVersion) = Load(versionsFilePath, loggingService);
+        TeamsModuleVersion = teamsVersion;
+        GraphModuleVersion = graphVersion;
+        PowerShellSdkVersion = sdkVersion;
+    }
+
+    private static (string teams, string graph, string sdk) Load(string path, ILoggingService? loggingService)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                loggingService?.Log($"Bundled module versions file not found at {path}", LogLevel.Warning);
+                return (UnknownVersion, UnknownVersion, UnknownVersion);
+            }
+
+            using var stream = File.OpenRead(path);
+            using var doc = JsonDocument.Parse(stream);
+
+            var teams = UnknownVersion;
+            var graph = UnknownVersion;
+
+            if (doc.RootElement.TryGetProperty("modules", out var modules) &&
+                modules.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var module in modules.EnumerateArray())
+                {
+                    var name = module.TryGetProperty("name", out var nameElement) ? nameElement.GetString() : null;
+                    var version = module.TryGetProperty("version", out var versionElement) ? versionElement.GetString() : null;
+
+                    if (name is null || version is null)
+                    {
+                        continue;
+                    }
+
+                    if (string.Equals(name, "MicrosoftTeams", StringComparison.OrdinalIgnoreCase))
+                    {
+                        teams = version;
+                    }
+                    else if (name.StartsWith(GraphModulePrefix, StringComparison.OrdinalIgnoreCase) && graph == UnknownVersion)
+                    {
+                        graph = version;
+                    }
+                }
+            }
+
+            var sdk = doc.RootElement.TryGetProperty("powerShellSdkVersion", out var sdkElement)
+                ? sdkElement.GetString() ?? UnknownVersion
+                : UnknownVersion;
+
+            return (teams, graph, sdk);
+        }
+        catch (Exception ex)
+        {
+            loggingService?.Log($"Failed to read bundled module versions: {ex.Message}", LogLevel.Warning);
+            return (UnknownVersion, UnknownVersion, UnknownVersion);
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/MainWindow.axaml
+++ b/src/TeamsPhoneManager.Presentation/MainWindow.axaml
@@ -546,6 +546,51 @@
                             </Grid>
                         </StackPanel>
 
+                        <Border Height="1" Background="{DynamicResource HairlineBrush}"/>
+
+                        <!-- About Section -->
+                        <StackPanel Spacing="12">
+                            <TextBlock Text="About"
+                                     FontSize="16"
+                                     FontWeight="SemiBold"/>
+
+                            <Grid ColumnDefinitions="*,Auto" Margin="0,4,0,0">
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock Text="MicrosoftTeams Module"/>
+                                    <TextBlock Text="Bundled PowerShell module version"
+                                             FontSize="11" Opacity="0.6" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <TextBlock Grid.Column="1"
+                                         Text="{Binding BundledTeamsModuleVersion}"
+                                         Margin="12,0,0,0"
+                                         VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid ColumnDefinitions="*,Auto">
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock Text="Microsoft.Graph Modules"/>
+                                    <TextBlock Text="Bundled PowerShell module version"
+                                             FontSize="11" Opacity="0.6" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <TextBlock Grid.Column="1"
+                                         Text="{Binding BundledGraphModuleVersion}"
+                                         Margin="12,0,0,0"
+                                         VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid ColumnDefinitions="*,Auto">
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock Text="PowerShell SDK"/>
+                                    <TextBlock Text="Bundled PowerShell runtime version"
+                                             FontSize="11" Opacity="0.6" TextWrapping="Wrap"/>
+                                </StackPanel>
+                                <TextBlock Grid.Column="1"
+                                         Text="{Binding BundledPowerShellSdkVersion}"
+                                         Margin="12,0,0,0"
+                                         VerticalAlignment="Center"/>
+                            </Grid>
+                        </StackPanel>
+
                     </StackPanel>
                 </ScrollViewer>
             </Grid>

--- a/src/TeamsPhoneManager.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/MainWindowViewModel.cs
@@ -29,6 +29,7 @@ namespace teams_phonemanager.ViewModels
         private readonly IUpdateCheckService _updateCheckService;
         private readonly IUpdateInstallerService _updateInstallerService;
         private readonly IDialogService _updateDialogService;
+        private readonly IBundledModuleVersionService _bundledModuleVersionService;
         private UpdateInfo? _availableUpdate;
         private CancellationTokenSource? _updateCancellation;
 
@@ -54,6 +55,15 @@ namespace teams_phonemanager.ViewModels
         private double _updateDownloadProgress;
 
         private string? _updateReleaseUrl;
+
+        [ObservableProperty]
+        private string _bundledTeamsModuleVersion = string.Empty;
+
+        [ObservableProperty]
+        private string _bundledGraphModuleVersion = string.Empty;
+
+        [ObservableProperty]
+        private string _bundledPowerShellSdkVersion = string.Empty;
 
         private async Task CheckForUpdateAsync()
         {
@@ -351,7 +361,8 @@ namespace teams_phonemanager.ViewModels
             IDialogService dialogService,
             IPageViewModelFactory pageViewModelFactory,
             IUpdateCheckService updateCheckService,
-            IUpdateInstallerService updateInstallerService)
+            IUpdateInstallerService updateInstallerService,
+            IBundledModuleVersionService bundledModuleVersionService)
             : base(powerShellContextService, powerShellCommandService, loggingService,
                   sessionManager, navigationService, errorHandlingService, validationService, sharedStateService, dialogService)
         {
@@ -359,7 +370,12 @@ namespace teams_phonemanager.ViewModels
             _updateCheckService = updateCheckService;
             _updateInstallerService = updateInstallerService;
             _updateDialogService = dialogService;
+            _bundledModuleVersionService = bundledModuleVersionService;
             CurrentViewModel = _pageViewModelFactory.Create(CurrentPage);
+
+            BundledTeamsModuleVersion = _bundledModuleVersionService.TeamsModuleVersion;
+            BundledGraphModuleVersion = _bundledModuleVersionService.GraphModuleVersion;
+            BundledPowerShellSdkVersion = _bundledModuleVersionService.PowerShellSdkVersion;
 
             _loggingService.Log("Application started", LogLevel.Info);
 

--- a/teams-phonemanager.Tests/BundledModuleVersionServiceTests.cs
+++ b/teams-phonemanager.Tests/BundledModuleVersionServiceTests.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using teams_phonemanager.Services;
+using Xunit;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Covers <see cref="BundledModuleVersionService"/>'s parsing of the pinned-version manifest,
+    /// including its fail-silent behavior when the file is missing or malformed. Uses the
+    /// explicit-path constructor overload as a test seam instead of the app's output directory.
+    /// </summary>
+    public class BundledModuleVersionServiceTests : IDisposable
+    {
+        private readonly string _tempDir = Directory.CreateTempSubdirectory("bundled-module-version-test-").FullName;
+
+        [Fact]
+        public void ValidManifest_ExposesTeamsGraphAndSdkVersions()
+        {
+            const string json = """
+                {
+                  "modules": [
+                    { "name": "MicrosoftTeams", "version": "6.9.0" },
+                    { "name": "Microsoft.Graph.Authentication", "version": "2.25.0" },
+                    { "name": "Microsoft.Graph.Users", "version": "2.25.0" }
+                  ],
+                  "powerShellSdkVersion": "7.6.0"
+                }
+                """;
+
+            var service = new BundledModuleVersionService(WriteManifest(json));
+
+            Assert.Equal("6.9.0", service.TeamsModuleVersion);
+            Assert.Equal("2.25.0", service.GraphModuleVersion);
+            Assert.Equal("7.6.0", service.PowerShellSdkVersion);
+        }
+
+        [Fact]
+        public void MissingManifest_ReturnsUnknownForAllVersionsAndDoesNotThrow()
+        {
+            var missingPath = Path.Combine(_tempDir, "does-not-exist.json");
+
+            var service = new BundledModuleVersionService(missingPath);
+
+            Assert.Equal("Unknown", service.TeamsModuleVersion);
+            Assert.Equal("Unknown", service.GraphModuleVersion);
+            Assert.Equal("Unknown", service.PowerShellSdkVersion);
+        }
+
+        [Fact]
+        public void MalformedManifest_ReturnsUnknownVersionsAndDoesNotThrow()
+        {
+            var service = new BundledModuleVersionService(WriteManifest("{ not valid json"));
+
+            Assert.Equal("Unknown", service.TeamsModuleVersion);
+            Assert.Equal("Unknown", service.GraphModuleVersion);
+            Assert.Equal("Unknown", service.PowerShellSdkVersion);
+        }
+
+        private string WriteManifest(string json)
+        {
+            var path = Path.Combine(_tempDir, "module-versions.json");
+            File.WriteAllText(path, json);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+    }
+}

--- a/teams-phonemanager.Tests/MainWindowViewModelTests.cs
+++ b/teams-phonemanager.Tests/MainWindowViewModelTests.cs
@@ -20,8 +20,8 @@ namespace teams_phonemanager.Tests
             // object resolved via the factory, it never inspects the concrete type itself.
             _pageViewModelFactory.Setup(f => f.Create(It.IsAny<string>())).Returns((ViewModelBase)null!);
             _updateCheckService.Setup(u => u.CheckForUpdateAsync(It.IsAny<CancellationToken>())).ReturnsAsync((UpdateInfo?)null);
-            _bundledModuleVersionService.SetupGet(m => m.TeamsModuleVersion).Returns("6.9.0");
-            _bundledModuleVersionService.SetupGet(m => m.GraphModuleVersion).Returns("2.25.0");
+            _bundledModuleVersionService.SetupGet(m => m.TeamsModuleVersion).Returns("7.8.0");
+            _bundledModuleVersionService.SetupGet(m => m.GraphModuleVersion).Returns("2.38.1");
             _bundledModuleVersionService.SetupGet(m => m.PowerShellSdkVersion).Returns("7.6.0");
         }
 

--- a/teams-phonemanager.Tests/MainWindowViewModelTests.cs
+++ b/teams-phonemanager.Tests/MainWindowViewModelTests.cs
@@ -12,6 +12,7 @@ namespace teams_phonemanager.Tests
         private readonly Mock<IPageViewModelFactory> _pageViewModelFactory = new();
         private readonly Mock<IUpdateCheckService> _updateCheckService = new();
         private readonly Mock<IUpdateInstallerService> _updateInstallerService = new();
+        private readonly Mock<IBundledModuleVersionService> _bundledModuleVersionService = new();
 
         public MainWindowViewModelTests()
         {
@@ -19,6 +20,9 @@ namespace teams_phonemanager.Tests
             // object resolved via the factory, it never inspects the concrete type itself.
             _pageViewModelFactory.Setup(f => f.Create(It.IsAny<string>())).Returns((ViewModelBase)null!);
             _updateCheckService.Setup(u => u.CheckForUpdateAsync(It.IsAny<CancellationToken>())).ReturnsAsync((UpdateInfo?)null);
+            _bundledModuleVersionService.SetupGet(m => m.TeamsModuleVersion).Returns("6.9.0");
+            _bundledModuleVersionService.SetupGet(m => m.GraphModuleVersion).Returns("2.25.0");
+            _bundledModuleVersionService.SetupGet(m => m.PowerShellSdkVersion).Returns("7.6.0");
         }
 
         private MainWindowViewModel CreateViewModel(ViewModelTestHarness harness)
@@ -40,7 +44,8 @@ namespace teams_phonemanager.Tests
                 harness.DialogService.Object,
                 _pageViewModelFactory.Object,
                 _updateCheckService.Object,
-                _updateInstallerService.Object);
+                _updateInstallerService.Object,
+                _bundledModuleVersionService.Object);
         }
 
         [Fact]

--- a/teams-phonemanager.Tests/ModuleVersionsFileTests.cs
+++ b/teams-phonemanager.Tests/ModuleVersionsFileTests.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Validates the pinned-version manifest consumed by Scripts/download-modules.ps1/.sh and by
+    /// <c>BundledModuleVersionService</c> at runtime.
+    /// </summary>
+    public class ModuleVersionsFileTests
+    {
+        private static readonly string[] ExpectedModuleNames =
+        {
+            "MicrosoftTeams",
+            "Microsoft.Graph.Authentication",
+            "Microsoft.Graph.Users",
+            "Microsoft.Graph.Users.Actions",
+            "Microsoft.Graph.Groups",
+            "Microsoft.Graph.Identity.DirectoryManagement",
+        };
+
+        [Fact]
+        public void ModuleVersionsJson_ParsesAndContainsAllExpectedModulesWithVersions()
+        {
+            var path = FindModuleVersionsFile();
+            Assert.True(File.Exists(path), $"Scripts/module-versions.json not found (searched up from {AppContext.BaseDirectory})");
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+
+            Assert.True(doc.RootElement.TryGetProperty("modules", out var modules));
+            Assert.Equal(JsonValueKind.Array, modules.ValueKind);
+
+            var foundNames = new List<string>();
+            foreach (var module in modules.EnumerateArray())
+            {
+                var name = module.GetProperty("name").GetString();
+                var version = module.GetProperty("version").GetString();
+
+                Assert.False(string.IsNullOrWhiteSpace(name));
+                Assert.False(string.IsNullOrWhiteSpace(version));
+                foundNames.Add(name!);
+            }
+
+            foreach (var expected in ExpectedModuleNames)
+            {
+                Assert.Contains(expected, foundNames);
+            }
+
+            Assert.True(doc.RootElement.TryGetProperty("powerShellSdkVersion", out var sdkVersion));
+            Assert.False(string.IsNullOrWhiteSpace(sdkVersion.GetString()));
+        }
+
+        /// <summary>
+        /// Walks up from the test's execution directory to find the repo root, identified by
+        /// the presence of the solution file, then returns the path to Scripts/module-versions.json.
+        /// </summary>
+        private static string FindModuleVersionsFile()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                var candidate = Path.Combine(dir.FullName, "Scripts", "module-versions.json");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+
+                if (dir.GetFiles("*.slnx").Length > 0 || dir.GetFiles("*.sln").Length > 0)
+                {
+                    return Path.Combine(dir.FullName, "Scripts", "module-versions.json");
+                }
+
+                dir = dir.Parent;
+            }
+
+            throw new FileNotFoundException("Could not locate repo root (no *.slnx/*.sln found while walking up).");
+        }
+    }
+}

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -80,6 +80,11 @@
     <Content Include="Modules\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <!-- Bundled-module version pins, read at runtime by BundledModuleVersionService
+         to populate the Settings/About panel. -->
+    <Content Include="Scripts\module-versions.json" Link="Scripts\module-versions.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
Fixes #77

## Summary
- Added `Scripts/module-versions.json` as the single declarative source of pinned versions for the bundled MicrosoftTeams and Microsoft.Graph.* modules, plus the bundled PowerShell SDK version string.
- Updated `Scripts/download-modules.ps1` and `Scripts/download-modules.sh` to read the pinned versions from that file and download the exact pinned version from the PowerShell Gallery (`.../package/{module}/{version}`) instead of the floating "latest" endpoint. No other behavior (logging, structure, output paths, error handling) was changed.
- `teams-phonemanager.csproj` now copies `Scripts/module-versions.json` to the app's output directory so it can be read at runtime.
- Added `IBundledModuleVersionService` (Application) / `BundledModuleVersionService` (Infrastructure) to read the pinned versions file, registered in `Program.cs`, following the same interface-in-Application/impl-in-Infrastructure pattern as `IUpdateCheckService`.
- Surfaced the bundled MicrosoftTeams version, Microsoft.Graph version, and PowerShell SDK version in a new "About" section of the existing Settings side panel (`MainWindowViewModel` + `MainWindow.axaml`), matching the existing settings-panel markup/binding conventions.
- Added `.github/workflows/module-compatibility.yml`: a schedule-only (weekly cron + manual dispatch) workflow that checks the PowerShell Gallery for newer module versions, and if found, bumps the pin file and runs the full build/test suite against the update — opening a PR with changelog links on success, or a GitHub issue with failure logs otherwise. It is not wired into push/PR checks.
- Added tests: `ModuleVersionsFileTests` (validates `module-versions.json` parses and contains all expected modules with version strings) and `BundledModuleVersionServiceTests` (validates the service parses a manifest correctly, including the "file missing" fallback path).
- Documented the pinning/upgrade policy in `README.md`.

## Test plan
- [x] `dotnet build TeamsPhoneManager.slnx --configuration Release` — succeeds, 0 warnings/errors
- [x] `dotnet test teams-phonemanager.Tests/teams-phonemanager.Tests.csproj --configuration Release --no-build` — 470/470 passed, including `DependencyRuleTests` (Clean Architecture layering intact)
- [ ] Manual verification of the new About section in the running app (not done in this environment — no GUI)
- [ ] The `module-compatibility.yml` workflow's PowerShell Gallery query is best-effort and can only be fully validated by an actual scheduled run on GitHub Actions

## Note on pinned versions
Pins were verified against the PowerShell Gallery and set to the current latest stable releases (MicrosoftTeams 7.8.0, Microsoft.Graph.* 2.38.1, PowerShell SDK 7.6.0 matching the csproj) — this matches the previous effective behavior of the download scripts, which fetched `latest` before this PR. The initial pins in this PR (6.9.0 / 2.25.0) were stale and would have silently downgraded the bundled modules; they have been corrected in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
