### PR TITLE
feat: dry-run preview with exportable plan for wizard and bulk operations

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using teams_phonemanager.Planning;
 using teams_phonemanager.Services;
 using teams_phonemanager.Services.Interfaces;
 using teams_phonemanager.Services.ScriptBuilders;
@@ -78,6 +79,12 @@ class Program
         services.AddTransient<ResourceAccountScriptBuilder>();
         services.AddTransient<IDocumentationScriptBuilder, DocumentationScriptBuilder>();
         services.AddTransient<BulkOperationsScriptBuilder>();
+
+        // Dry-run preview (issue #68): read-only plan generation + exportable plan. Neither touches the
+        // tenant, executes PowerShell, nor generates script text — the plan derives purely from the same
+        // configuration inputs the frozen script builders consume.
+        services.AddTransient<IDryRunPlanBuilder, DryRunPlanBuilder>();
+        services.AddTransient<IDryRunPlanExporter, DryRunPlanExporter>();
 
         // ViewModels (transient - new instance per navigation)
         services.AddTransient<MainWindowViewModel>();

--- a/src/TeamsPhoneManager.Application/Interfaces/IDryRunPlanBuilder.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IDryRunPlanBuilder.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+
+namespace teams_phonemanager.Services.Interfaces
+{
+    /// <summary>
+    /// Builds a structured <see cref="DryRunPlan"/> from configuration inputs. The plan is a read-only
+    /// projection of what a run would create/change; building it performs no tenant mutation and executes
+    /// no PowerShell. It derives entirely from <see cref="IPhoneManagerVariables"/> (the same inputs the
+    /// frozen script builders consume) so the preview can never diverge from actual execution.
+    /// </summary>
+    public interface IDryRunPlanBuilder
+    {
+        /// <summary>Builds a single-entry plan for one configuration (used by the setup wizard).</summary>
+        DryRunPlan BuildWizardPlan(IPhoneManagerVariables variables);
+
+        /// <summary>Builds a multi-entry plan, one entry per configuration (used by bulk CSV operations).</summary>
+        DryRunPlan BuildBulkPlan(IReadOnlyList<IPhoneManagerVariables> entries);
+    }
+}

--- a/src/TeamsPhoneManager.Application/Interfaces/IDryRunPlanExporter.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IDryRunPlanExporter.cs
@@ -1,0 +1,17 @@
+using teams_phonemanager.Planning;
+
+namespace teams_phonemanager.Services.Interfaces
+{
+    /// <summary>
+    /// Serializes a <see cref="DryRunPlan"/> into a portable document for change-approval workflows.
+    /// Pure text projection — produces a string, performs no file or network IO.
+    /// </summary>
+    public interface IDryRunPlanExporter
+    {
+        /// <summary>Serializes the plan as indented JSON.</summary>
+        string ToJson(DryRunPlan plan);
+
+        /// <summary>Serializes the plan as CSV, one row per planned object.</summary>
+        string ToCsv(DryRunPlan plan);
+    }
+}

--- a/src/TeamsPhoneManager.Application/Planning/DryRunPlanBuilder.cs
+++ b/src/TeamsPhoneManager.Application/Planning/DryRunPlanBuilder.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Planning
+{
+    /// <summary>
+    /// Produces a <see cref="DryRunPlan"/> from configuration inputs without touching the tenant or the
+    /// PowerShell/Graph layers. The enumerated objects mirror, as descriptive metadata only, the sequence
+    /// of operations the wizard and bulk script builders perform for one setup:
+    /// M365 Group → CQ Resource Account → CQ License → Call Queue → AA Resource Account →
+    /// AA License + Phone Number → Auto Attendant → Association. It never generates or inspects script text,
+    /// so it cannot influence what the frozen builders emit at execution time.
+    /// </summary>
+    public class DryRunPlanBuilder : IDryRunPlanBuilder
+    {
+        private readonly IValidationService _validationService;
+
+        public DryRunPlanBuilder(IValidationService validationService)
+        {
+            _validationService = validationService;
+        }
+
+        public DryRunPlan BuildWizardPlan(IPhoneManagerVariables variables)
+        {
+            var entry = BuildEntry(variables, rowNumber: 1);
+            var entries = new List<DryRunEntry> { entry };
+            ApplyCrossEntryPreflight(entries, new[] { variables });
+            return new DryRunPlan("Setup Wizard", DateTimeOffset.UtcNow, entries);
+        }
+
+        public DryRunPlan BuildBulkPlan(IReadOnlyList<IPhoneManagerVariables> entries)
+        {
+            var built = new List<DryRunEntry>(entries.Count);
+            for (int i = 0; i < entries.Count; i++)
+            {
+                built.Add(BuildEntry(entries[i], rowNumber: i + 1));
+            }
+            ApplyCrossEntryPreflight(built, entries);
+            return new DryRunPlan("Bulk Operations (CSV)", DateTimeOffset.UtcNow, built);
+        }
+
+        private DryRunEntry BuildEntry(IPhoneManagerVariables v, int rowNumber)
+        {
+            var label = BuildLabel(v);
+            var objects = BuildObjects(v);
+            var errors = ValidateForCreateFlow(v);
+
+            // Per-entry preflight is populated by ApplyCrossEntryPreflight after all entries exist, since the
+            // only checks that do not require live-tenant access are intra-plan duplicate detections.
+            return new DryRunEntry(rowNumber, label, objects, errors, Array.Empty<PreflightCheck>());
+        }
+
+        private static string BuildLabel(IPhoneManagerVariables v)
+        {
+            var customer = string.IsNullOrWhiteSpace(v.Customer) ? "(no customer)" : v.Customer;
+            var group = string.IsNullOrWhiteSpace(v.CustomerGroupName) ? "(no group)" : v.CustomerGroupName;
+            return $"{customer} - {group}";
+        }
+
+        private static IReadOnlyList<PlannedObject> BuildObjects(IPhoneManagerVariables v)
+        {
+            var objects = new List<PlannedObject>
+            {
+                new(PlannedObjectType.M365Group, PlannedAction.Create, v.M365Group, null,
+                    new List<PlannedSetting>
+                    {
+                        new("Name", v.M365Group)
+                    }),
+
+                new(PlannedObjectType.ResourceAccount, PlannedAction.Create, v.RacqDisplayName, v.RacqUPN,
+                    new List<PlannedSetting>
+                    {
+                        new("Display Name", v.RacqDisplayName),
+                        new("UPN", v.RacqUPN),
+                        new("Purpose", "Call Queue")
+                    }),
+
+                new(PlannedObjectType.License, PlannedAction.Assign, v.RacqDisplayName, v.RacqUPN,
+                    new List<PlannedSetting>
+                    {
+                        new("Usage Location", v.UsageLocation),
+                        new("SKU", v.SkuId)
+                    }),
+
+                new(PlannedObjectType.CallQueue, PlannedAction.Create, v.CqDisplayName, null,
+                    new List<PlannedSetting>
+                    {
+                        new("Display Name", v.CqDisplayName),
+                        new("Language", v.LanguageId)
+                    }),
+
+                new(PlannedObjectType.ResourceAccount, PlannedAction.Create, v.RaaaDisplayName, v.RaaaUPN,
+                    new List<PlannedSetting>
+                    {
+                        new("Display Name", v.RaaaDisplayName),
+                        new("UPN", v.RaaaUPN),
+                        new("Purpose", "Auto Attendant")
+                    }),
+
+                new(PlannedObjectType.License, PlannedAction.Assign, v.RaaaDisplayName, v.RaaaUPN,
+                    new List<PlannedSetting>
+                    {
+                        new("Usage Location", v.UsageLocation),
+                        new("SKU", v.SkuId)
+                    })
+            };
+
+            if (!string.IsNullOrWhiteSpace(v.RaaAnr))
+            {
+                objects.Add(new PlannedObject(PlannedObjectType.PhoneNumber, PlannedAction.Assign, v.RaaaDisplayName, v.RaaaUPN,
+                    new List<PlannedSetting>
+                    {
+                        new("Phone Number", v.RaaAnr),
+                        new("Number Type", v.PhoneNumberType)
+                    }));
+            }
+
+            objects.Add(new PlannedObject(PlannedObjectType.AutoAttendant, PlannedAction.Create, v.AaDisplayName, null,
+                new List<PlannedSetting>
+                {
+                    new("Display Name", v.AaDisplayName),
+                    new("Language", v.LanguageId),
+                    new("Time Zone", v.TimeZoneId)
+                }));
+
+            objects.Add(new PlannedObject(PlannedObjectType.Association, PlannedAction.Associate, v.AaDisplayName, v.RaaaUPN,
+                new List<PlannedSetting>
+                {
+                    new("Resource Account", v.RaaaUPN),
+                    new("Auto Attendant", v.AaDisplayName)
+                }));
+
+            return objects;
+        }
+
+        /// <summary>
+        /// Validates the fields the create flow actually consumes. This deliberately does not reuse
+        /// <see cref="IValidationService.ValidateVariables"/>, which additionally requires holiday and
+        /// greeting-prompt fields that belong to later, separate pages and are not set during wizard/bulk
+        /// creation — reusing it would flag every valid creation entry as invalid.
+        /// </summary>
+        private IReadOnlyList<string> ValidateForCreateFlow(IPhoneManagerVariables v)
+        {
+            var errors = new List<string>();
+
+            void Require(string value, string field)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    errors.Add($"{field} is required.");
+            }
+
+            Require(v.Customer, "Customer");
+            Require(v.CustomerGroupName, "Customer group name");
+            Require(v.MsFallbackDomain, "Microsoft fallback domain");
+            Require(v.LanguageId, "Language ID");
+            Require(v.TimeZoneId, "Time zone ID");
+            Require(v.UsageLocation, "Usage location");
+            Require(v.PhoneNumberType, "Phone number type");
+
+            if (string.IsNullOrWhiteSpace(v.RaaAnr))
+            {
+                errors.Add("Resource account phone number is required.");
+            }
+            else if (!_validationService.IsValidPhoneNumber(v.RaaAnr))
+            {
+                errors.Add($"Phone number '{v.RaaAnr}' is not a valid E.164 number.");
+            }
+
+            return errors;
+        }
+
+        /// <summary>
+        /// Appends preflight checks that can be evaluated without live-tenant access: intra-plan duplicate
+        /// detection (two entries resolving to the same group, UPN, or phone number would collide on
+        /// creation). Live-tenant collision/license/number-availability checks are reported as
+        /// <see cref="PreflightStatus.NotChecked"/> so the preview never claims a guarantee it did not verify.
+        /// </summary>
+        private static void ApplyCrossEntryPreflight(List<DryRunEntry> built, IReadOnlyList<IPhoneManagerVariables> sources)
+        {
+            var groupCounts = CountOccurrences(sources.Select(s => s.M365Group));
+            var racqCounts = CountOccurrences(sources.Select(s => s.RacqUPN));
+            var raaaCounts = CountOccurrences(sources.Select(s => s.RaaaUPN));
+            var numberCounts = CountOccurrences(sources.Select(s => s.RaaAnr));
+
+            for (int i = 0; i < built.Count; i++)
+            {
+                var v = sources[i];
+                var checks = new List<PreflightCheck>();
+
+                AddDuplicateCheck(checks, "M365 Group name unique in plan", v.M365Group, groupCounts);
+                AddDuplicateCheck(checks, "CQ resource account UPN unique in plan", v.RacqUPN, racqCounts);
+                AddDuplicateCheck(checks, "AA resource account UPN unique in plan", v.RaaaUPN, raaaCounts);
+                AddDuplicateCheck(checks, "Phone number unique in plan", v.RaaAnr, numberCounts);
+
+                checks.Add(new PreflightCheck(
+                    "Live tenant collision / license / number availability",
+                    PreflightStatus.NotChecked,
+                    "Not verified during preview. Requires an authenticated tenant query; run the operation to validate against live state."));
+
+                built[i] = built[i] with { PreflightChecks = checks };
+            }
+        }
+
+        private static void AddDuplicateCheck(List<PreflightCheck> checks, string name, string value, IReadOnlyDictionary<string, int> counts)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return; // Missing values are already reported by validation; don't double-count as a collision.
+
+            if (counts.TryGetValue(value, out var count) && count > 1)
+            {
+                checks.Add(new PreflightCheck(name, PreflightStatus.Fail,
+                    $"'{value}' appears in {count} entries; each must be unique."));
+            }
+            else
+            {
+                checks.Add(new PreflightCheck(name, PreflightStatus.Pass, $"'{value}' is unique within the plan."));
+            }
+        }
+
+        private static IReadOnlyDictionary<string, int> CountOccurrences(IEnumerable<string> values)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            foreach (var value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+                counts[value] = counts.TryGetValue(value, out var c) ? c + 1 : 1;
+            }
+            return counts;
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Domain/Planning/DryRunPlan.cs
+++ b/src/TeamsPhoneManager.Domain/Planning/DryRunPlan.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace teams_phonemanager.Planning
+{
+    /// <summary>
+    /// The kind of tenant object a <see cref="PlannedObject"/> describes. Purely descriptive metadata for
+    /// the dry-run preview — it never drives script generation and has no effect on what is executed.
+    /// </summary>
+    public enum PlannedObjectType
+    {
+        M365Group,
+        ResourceAccount,
+        License,
+        PhoneNumber,
+        CallQueue,
+        AutoAttendant,
+        Association
+    }
+
+    /// <summary>The action a <see cref="PlannedObject"/> would perform when the plan is executed.</summary>
+    public enum PlannedAction
+    {
+        Create,
+        Assign,
+        Associate
+    }
+
+    /// <summary>Outcome of a preflight check evaluated while building the plan.</summary>
+    public enum PreflightStatus
+    {
+        /// <summary>The check passed.</summary>
+        Pass,
+
+        /// <summary>The check surfaced a non-fatal concern the operator should be aware of.</summary>
+        Warning,
+
+        /// <summary>The check failed; executing as-is would very likely error.</summary>
+        Fail,
+
+        /// <summary>
+        /// The check could not be evaluated in this build (e.g. a live-tenant lookup that is not performed
+        /// during preview). Reported honestly rather than silently claiming success.
+        /// </summary>
+        NotChecked
+    }
+
+    /// <summary>A single resolved setting on a planned object (e.g. "UPN" → "racq-contoso-...").</summary>
+    public sealed record PlannedSetting(string Name, string Value);
+
+    /// <summary>A single object that would be created/changed for one entry, with its resolved settings.</summary>
+    public sealed record PlannedObject(
+        PlannedObjectType Type,
+        PlannedAction Action,
+        string DisplayName,
+        string? Upn,
+        IReadOnlyList<PlannedSetting> Settings)
+    {
+        /// <summary>Human-readable one-line summary, e.g. "Create M365Group: ttgrp-contoso-hauptnummer".</summary>
+        public string Summary => $"{Action} {Type}: {DisplayName}";
+    }
+
+    /// <summary>A preflight check result attached to an entry.</summary>
+    public sealed record PreflightCheck(string Name, PreflightStatus Status, string Detail);
+
+    /// <summary>
+    /// One complete setup in the plan. For the wizard this is the single configuration under review; for
+    /// bulk operations there is one entry per CSV row. Carries the objects that would be created, the
+    /// validation errors found in the source data, and the preflight checks that were evaluated.
+    /// </summary>
+    public sealed record DryRunEntry(
+        int RowNumber,
+        string Label,
+        IReadOnlyList<PlannedObject> Objects,
+        IReadOnlyList<string> ValidationErrors,
+        IReadOnlyList<PreflightCheck> PreflightChecks)
+    {
+        /// <summary>True when the entry has no validation errors and no failing preflight checks.</summary>
+        public bool IsValid =>
+            ValidationErrors.Count == 0 &&
+            !PreflightChecks.Any(c => c.Status == PreflightStatus.Fail);
+
+        /// <summary>Comma-joined validation errors for compact display/export.</summary>
+        public string ValidationSummary => string.Join("; ", ValidationErrors);
+    }
+
+    /// <summary>
+    /// An immutable, structured description of what a run <b>would</b> create or change, produced purely from
+    /// the same configuration inputs the script builders consume. Generating or exporting a plan performs no
+    /// tenant mutation and executes no PowerShell — it is a read-only projection used for review, approval,
+    /// and export. It deliberately does not carry any generated script text so it can never diverge from,
+    /// or influence, what the frozen builders emit at execution time.
+    /// </summary>
+    public sealed record DryRunPlan(
+        string Source,
+        DateTimeOffset GeneratedUtc,
+        IReadOnlyList<DryRunEntry> Entries)
+    {
+        public int EntryCount => Entries.Count;
+        public int ValidEntryCount => Entries.Count(e => e.IsValid);
+        public int InvalidEntryCount => Entries.Count(e => !e.IsValid);
+        public int TotalObjectCount => Entries.Sum(e => e.Objects.Count);
+
+        /// <summary>True when every entry in the plan is valid (safe to execute without skipping rows).</summary>
+        public bool IsFullyValid => Entries.Count > 0 && Entries.All(e => e.IsValid);
+
+        /// <summary>The entries that would actually execute when invalid rows are skipped.</summary>
+        public IReadOnlyList<DryRunEntry> ValidEntries => Entries.Where(e => e.IsValid).ToList();
+    }
+}

--- a/src/TeamsPhoneManager.Infrastructure/Planning/DryRunPlanExporter.cs
+++ b/src/TeamsPhoneManager.Infrastructure/Planning/DryRunPlanExporter.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Planning
+{
+    /// <summary>
+    /// Serializes a <see cref="DryRunPlan"/> to JSON or CSV for change-approval workflows. Pure text
+    /// projection — it produces strings only and performs no file or network IO (the Presentation layer
+    /// owns the actual save dialog). Enums are written as names for human-readable, diff-friendly output.
+    /// </summary>
+    public class DryRunPlanExporter : IDryRunPlanExporter
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        public string ToJson(DryRunPlan plan)
+        {
+            // Project to an explicit shape so the exported document is stable and independent of the
+            // Domain record's member layout / computed-property serialization quirks.
+            var dto = new
+            {
+                plan.Source,
+                GeneratedUtc = plan.GeneratedUtc,
+                plan.EntryCount,
+                plan.ValidEntryCount,
+                plan.InvalidEntryCount,
+                plan.TotalObjectCount,
+                plan.IsFullyValid,
+                Entries = plan.Entries.Select(e => new
+                {
+                    e.RowNumber,
+                    e.Label,
+                    e.IsValid,
+                    ValidationErrors = e.ValidationErrors,
+                    PreflightChecks = e.PreflightChecks.Select(c => new { c.Name, Status = c.Status, c.Detail }),
+                    Objects = e.Objects.Select(o => new
+                    {
+                        Type = o.Type,
+                        Action = o.Action,
+                        o.DisplayName,
+                        o.Upn,
+                        Settings = o.Settings.ToDictionary(s => s.Name, s => s.Value)
+                    })
+                })
+            };
+
+            return JsonSerializer.Serialize(dto, JsonOptions);
+        }
+
+        public string ToCsv(DryRunPlan plan)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(string.Join(",", new[]
+            {
+                "Entry", "Label", "EntryValid", "ObjectType", "Action", "DisplayName", "UPN", "Settings", "ValidationErrors"
+            }));
+
+            foreach (var entry in plan.Entries)
+            {
+                var errors = entry.ValidationSummary;
+
+                if (entry.Objects.Count == 0)
+                {
+                    sb.AppendLine(Row(entry, "", "", "", "", "", errors));
+                    continue;
+                }
+
+                foreach (var obj in entry.Objects)
+                {
+                    var settings = string.Join("; ", obj.Settings.Select(s => $"{s.Name}={s.Value}"));
+                    sb.AppendLine(Row(entry, obj.Type.ToString(), obj.Action.ToString(), obj.DisplayName, obj.Upn ?? "", settings, errors));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string Row(DryRunEntry entry, string type, string action, string displayName, string upn, string settings, string errors)
+        {
+            var fields = new[]
+            {
+                entry.RowNumber.ToString(),
+                entry.Label,
+                entry.IsValid ? "true" : "false",
+                type,
+                action,
+                displayName,
+                upn,
+                settings,
+                errors
+            };
+            return string.Join(",", fields.Select(EscapeCsv));
+        }
+
+        private static string EscapeCsv(string field)
+        {
+            if (string.IsNullOrEmpty(field))
+                return string.Empty;
+
+            if (field.Contains('"') || field.Contains(',') || field.Contains('\n') || field.Contains('\r'))
+            {
+                return "\"" + field.Replace("\"", "\"\"") + "\"";
+            }
+            return field;
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/Helpers/DryRunPlanExportHelper.cs
+++ b/src/TeamsPhoneManager.Presentation/Helpers/DryRunPlanExportHelper.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Platform.Storage;
+
+namespace teams_phonemanager.Helpers
+{
+    /// <summary>
+    /// Shared helper for saving an exported dry-run plan to disk via Avalonia's platform
+    /// <see cref="IStorageProvider"/>. Keeps the file-picker plumbing out of the view models and identical
+    /// between the wizard and bulk-operations pages. Returns the saved file name, or null if the user
+    /// cancelled or no window was available.
+    /// </summary>
+    internal static class DryRunPlanExportHelper
+    {
+        public static async Task<string?> SavePlanAsync(string content, string suggestedFileName, string extension)
+        {
+            var topLevel = Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+                ? desktop.MainWindow
+                : null;
+
+            if (topLevel == null)
+                return null;
+
+            var isJson = string.Equals(extension, "json", StringComparison.OrdinalIgnoreCase);
+            var typeName = isJson ? "JSON Files" : "CSV Files";
+            var pattern = isJson ? "*.json" : "*.csv";
+
+            var file = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = "Export Dry-Run Plan",
+                DefaultExtension = extension,
+                SuggestedFileName = suggestedFileName,
+                FileTypeChoices = new[]
+                {
+                    new FilePickerFileType(typeName) { Patterns = new[] { pattern } }
+                }
+            });
+
+            if (file == null)
+                return null;
+
+            await using var stream = await file.OpenWriteAsync();
+            await using var writer = new System.IO.StreamWriter(stream, Encoding.UTF8);
+            await writer.WriteAsync(content);
+            return file.Name;
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/ViewModels/BulkOperationsViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/BulkOperationsViewModel.cs
@@ -4,9 +4,13 @@ using teams_phonemanager.Services.Interfaces;
 using teams_phonemanager.Services;
 using teams_phonemanager.Services.ScriptBuilders;
 using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Helpers;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -15,6 +19,22 @@ namespace teams_phonemanager.ViewModels
     public partial class BulkOperationsViewModel : ViewModelBase
     {
         private readonly BulkOperationsScriptBuilder _bulkBuilder;
+        private readonly IDryRunPlanBuilder? _planBuilder;
+        private readonly IDryRunPlanExporter? _planExporter;
+
+        /// <summary>
+        /// The most recently generated dry-run plan for the parsed CSV entries. Null until the operator
+        /// generates a preview. Generating it performs no tenant mutation and executes no PowerShell.
+        /// </summary>
+        [ObservableProperty]
+        private DryRunPlan? _plan;
+
+        /// <summary>
+        /// When true, executing bulk operations skips entries that failed validation/preflight instead of
+        /// blocking the whole run. Off by default: nothing executes while any row is invalid.
+        /// </summary>
+        [ObservableProperty]
+        private bool _skipInvalidRows;
 
         [ObservableProperty]
         private string _csvContent = string.Empty;
@@ -48,11 +68,15 @@ namespace teams_phonemanager.ViewModels
             ISharedStateService sharedStateService,
             IDialogService dialogService,
             BulkOperationsScriptBuilder bulkBuilder,
+            IDryRunPlanBuilder? planBuilder = null,
+            IDryRunPlanExporter? planExporter = null,
             IAuditLog? auditLog = null)
             : base(powerShellContextService, powerShellCommandService, loggingService,
                   sessionManager, navigationService, errorHandlingService, validationService, sharedStateService, dialogService, auditLog)
         {
             _bulkBuilder = bulkBuilder;
+            _planBuilder = planBuilder;
+            _planExporter = planExporter;
             _loggingService.Log("Bulk Operations page loaded", LogLevel.Info);
         }
 
@@ -177,6 +201,72 @@ namespace teams_phonemanager.ViewModels
             StatusMessage = $"Script preview generated for {entries.Count} entries.";
         }
 
+        private List<PhoneManagerVariables> CollectParsedVariables() =>
+            ParsedEntries.Select(e => e.Variables).ToList();
+
+        /// <summary>
+        /// Builds a read-only dry-run plan for the parsed CSV: a per-row list of the objects that would be
+        /// created with resolved names/UPNs/number, per-row validation errors, and intra-plan preflight
+        /// (duplicate group/UPN/number across rows). Performs no tenant mutation and executes no PowerShell.
+        /// </summary>
+        [RelayCommand]
+        private void GeneratePlan()
+        {
+            if (_planBuilder == null)
+            {
+                StatusMessage = "Plan preview is unavailable.";
+                return;
+            }
+
+            if (ParsedEntries.Count == 0)
+            {
+                StatusMessage = "No entries to plan. Parse CSV first.";
+                return;
+            }
+
+            Plan = _planBuilder.BuildBulkPlan(CollectParsedVariables());
+            StatusMessage = Plan.InvalidEntryCount > 0
+                ? $"Plan generated: {Plan.ValidEntryCount} valid, {Plan.InvalidEntryCount} invalid of {Plan.EntryCount} rows. Fix issues or enable 'Skip invalid rows'."
+                : $"Plan generated: {Plan.EntryCount} rows, {Plan.TotalObjectCount} objects would be created/changed.";
+            _loggingService.Log($"Bulk dry-run plan generated: {Plan.EntryCount} rows ({Plan.InvalidEntryCount} invalid)", LogLevel.Info);
+        }
+
+        [RelayCommand]
+        private Task ExportPlanJsonAsync() => ExportPlanAsync(asJson: true);
+
+        [RelayCommand]
+        private Task ExportPlanCsvAsync() => ExportPlanAsync(asJson: false);
+
+        private async Task ExportPlanAsync(bool asJson)
+        {
+            if (_planBuilder == null || _planExporter == null)
+            {
+                StatusMessage = "Plan export is unavailable.";
+                return;
+            }
+
+            if (ParsedEntries.Count == 0)
+            {
+                StatusMessage = "No entries to export. Parse CSV first.";
+                return;
+            }
+
+            Plan ??= _planBuilder.BuildBulkPlan(CollectParsedVariables());
+
+            var content = asJson ? _planExporter.ToJson(Plan) : _planExporter.ToCsv(Plan);
+            var extension = asJson ? "json" : "csv";
+            var saved = await DryRunPlanExportHelper.SavePlanAsync(content, $"bulk-dry-run-plan.{extension}", extension);
+            if (saved != null)
+            {
+                StatusMessage = $"Plan exported to {saved}";
+                _loggingService.Log($"Bulk dry-run plan exported to: {saved}", LogLevel.Info);
+            }
+            else
+            {
+                StatusMessage = "Plan export cancelled.";
+            }
+        }
+
         [RelayCommand]
         private async Task ExecuteAllAsync()
         {
@@ -186,10 +276,35 @@ namespace teams_phonemanager.ViewModels
                 return;
             }
 
-            var entries = new System.Collections.Generic.List<PhoneManagerVariables>();
-            foreach (var entry in ParsedEntries)
+            var entries = CollectParsedVariables();
+
+            // Dry-run gate: validate the whole batch up front. Nothing executes while any row is invalid
+            // unless the operator explicitly opts into skipping invalid rows, in which case only the valid
+            // rows execute. This selects which entries run; it never alters the frozen builder's output for
+            // a given entry, so execution remains byte-identical.
+            if (_planBuilder != null)
             {
-                entries.Add(entry.Variables);
+                Plan = _planBuilder.BuildBulkPlan(entries);
+
+                if (Plan.InvalidEntryCount > 0)
+                {
+                    if (!SkipInvalidRows)
+                    {
+                        StatusMessage = $"{Plan.InvalidEntryCount} of {Plan.EntryCount} row(s) are invalid. Fix them, or enable 'Skip invalid rows' to run only the valid rows.";
+                        _loggingService.Log($"Bulk execution blocked: {Plan.InvalidEntryCount} invalid rows and skip-invalid is off", LogLevel.Warning);
+                        return;
+                    }
+
+                    var validEntries = Plan.ValidEntries.Select(e => entries[e.RowNumber - 1]).ToList();
+                    if (validEntries.Count == 0)
+                    {
+                        StatusMessage = "All rows are invalid. Nothing to execute.";
+                        return;
+                    }
+
+                    _loggingService.Log($"Bulk execution skipping {Plan.InvalidEntryCount} invalid row(s); running {validEntries.Count} valid row(s)", LogLevel.Warning);
+                    entries = validEntries;
+                }
             }
 
             var bulkScript = _bulkBuilder.GenerateBulkScript(entries);

--- a/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/WizardViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using teams_phonemanager.Services.Interfaces;
 using teams_phonemanager.Services;
 using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Helpers;
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -38,6 +40,16 @@ namespace teams_phonemanager.ViewModels
         [ObservableProperty]
         private ObservableCollection<WizardStepInfo> _steps = new();
 
+        private readonly IDryRunPlanBuilder? _planBuilder;
+        private readonly IDryRunPlanExporter? _planExporter;
+
+        /// <summary>
+        /// The most recently generated dry-run plan for the current configuration. Null until the operator
+        /// generates a preview. Generating it performs no tenant mutation and executes no PowerShell.
+        /// </summary>
+        [ObservableProperty]
+        private DryRunPlan? _plan;
+
         public bool CanGoNext => CurrentStep < TotalSteps - 1 && !StepFailed;
         public bool CanGoPrevious => CurrentStep > 0;
         public bool CanExecuteStep => !IsBusy && !StepCompleted;
@@ -54,10 +66,14 @@ namespace teams_phonemanager.ViewModels
             IValidationService validationService,
             ISharedStateService sharedStateService,
             IDialogService dialogService,
+            IDryRunPlanBuilder? planBuilder = null,
+            IDryRunPlanExporter? planExporter = null,
             IAuditLog? auditLog = null)
             : base(powerShellContextService, powerShellCommandService, loggingService,
                   sessionManager, navigationService, errorHandlingService, validationService, sharedStateService, dialogService, auditLog)
         {
+            _planBuilder = planBuilder;
+            _planExporter = planExporter;
             _loggingService.Log("Wizard page loaded", LogLevel.Info);
             InitializeSteps();
             UpdateCurrentStep();
@@ -305,6 +321,64 @@ namespace teams_phonemanager.ViewModels
         private void GoToHolidaysPage()
         {
             NavigateToHolidays();
+        }
+
+        /// <summary>
+        /// Builds a read-only dry-run plan for the current configuration: every object that would be created
+        /// with its resolved names, UPNs, number and settings, plus validation and preflight results. This
+        /// performs no tenant mutation and executes no PowerShell — it derives purely from the current
+        /// variables, so it can never diverge from what execution would emit.
+        /// </summary>
+        [RelayCommand]
+        private void GeneratePlan()
+        {
+            if (_planBuilder == null)
+            {
+                StatusMessage = "Plan preview is unavailable.";
+                return;
+            }
+
+            Plan = _planBuilder.BuildWizardPlan(Variables);
+            var entry = Plan.Entries.Count > 0 ? Plan.Entries[0] : null;
+            if (entry != null && !entry.IsValid)
+            {
+                StatusMessage = $"Plan generated with {entry.ValidationErrors.Count} validation issue(s). Review before executing.";
+            }
+            else
+            {
+                StatusMessage = $"Plan generated: {Plan.TotalObjectCount} objects would be created/changed.";
+            }
+            _loggingService.Log("Wizard dry-run plan generated", LogLevel.Info);
+        }
+
+        [RelayCommand]
+        private Task ExportPlanJsonAsync() => ExportPlanAsync(asJson: true);
+
+        [RelayCommand]
+        private Task ExportPlanCsvAsync() => ExportPlanAsync(asJson: false);
+
+        private async Task ExportPlanAsync(bool asJson)
+        {
+            if (_planBuilder == null || _planExporter == null)
+            {
+                StatusMessage = "Plan export is unavailable.";
+                return;
+            }
+
+            Plan ??= _planBuilder.BuildWizardPlan(Variables);
+
+            var content = asJson ? _planExporter.ToJson(Plan) : _planExporter.ToCsv(Plan);
+            var extension = asJson ? "json" : "csv";
+            var saved = await DryRunPlanExportHelper.SavePlanAsync(content, $"wizard-dry-run-plan.{extension}", extension);
+            if (saved != null)
+            {
+                StatusMessage = $"Plan exported to {saved}";
+                _loggingService.Log($"Wizard dry-run plan exported to: {saved}", LogLevel.Info);
+            }
+            else
+            {
+                StatusMessage = "Plan export cancelled.";
+            }
         }
 
         partial void OnCurrentStepChanged(int value)

--- a/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
@@ -71,6 +71,12 @@
                                 <TextBlock Text="Preview Script" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
+                        <Button Command="{Binding GeneratePlanCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
+                            <StackPanel Orientation="Horizontal">
+                                <fi:SymbolIcon Symbol="ClipboardTaskListLtr"/>
+                                <TextBlock Text="Dry-Run Plan" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <Button Command="{Binding ExecuteAllCommand}"
                                 Classes="accent IconText"
                                 IsEnabled="{Binding !IsBusy}">
@@ -79,6 +85,25 @@
                                 <TextBlock Text="Execute All" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
+                    </StackPanel>
+
+                    <!-- Dry-run plan export + safety toggle -->
+                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                        <Button Command="{Binding ExportPlanJsonCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
+                            <StackPanel Orientation="Horizontal">
+                                <fi:SymbolIcon Symbol="Code"/>
+                                <TextBlock Text="Export Plan (JSON)" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Command="{Binding ExportPlanCsvCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
+                            <StackPanel Orientation="Horizontal">
+                                <fi:SymbolIcon Symbol="DocumentTable"/>
+                                <TextBlock Text="Export Plan (CSV)" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
+                        <CheckBox IsChecked="{Binding SkipInvalidRows}"
+                                  Content="Skip invalid rows on execute"
+                                  VerticalAlignment="Center"/>
                     </StackPanel>
 
                     <!-- Status -->
@@ -145,6 +170,80 @@
                                 <DataGridTextColumn Header="Language" Binding="{Binding Language}" Width="80"/>
                             </DataGrid.Columns>
                         </DataGrid>
+                    </TabItem>
+
+                    <!-- Dry-Run Plan Tab -->
+                    <TabItem Header="Dry-Run Plan">
+                        <Grid RowDefinitions="Auto,*">
+                            <TextBlock Grid.Row="0"
+                                       Margin="0,8,0,8"
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                       IsVisible="{Binding Plan, Converter={x:Static ObjectConverters.IsNull}}"
+                                       Text="Click 'Dry-Run Plan' above to preview what would be created for each row before any execution."/>
+                            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                                <ItemsControl ItemsSource="{Binding Plan.Entries}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Classes="card" Margin="0,0,0,10" Padding="14">
+                                                <StackPanel Spacing="8">
+                                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                                        <fi:SymbolIcon Symbol="CheckmarkCircle"
+                                                                       Foreground="Green"
+                                                                       IsVisible="{Binding IsValid}"/>
+                                                        <fi:SymbolIcon Symbol="ErrorCircle"
+                                                                       Foreground="OrangeRed"
+                                                                       IsVisible="{Binding !IsValid}"/>
+                                                        <TextBlock Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                        <TextBlock Text="{Binding RowNumber, StringFormat='Row {0}'}"
+                                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                                   VerticalAlignment="Center"/>
+                                                    </StackPanel>
+
+                                                    <!-- Validation errors -->
+                                                    <ItemsControl ItemsSource="{Binding ValidationErrors}"
+                                                                  IsVisible="{Binding ValidationErrors.Count}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <TextBlock Text="{Binding}" Foreground="OrangeRed" FontSize="12" TextWrapping="Wrap"/>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+
+                                                    <!-- Planned objects -->
+                                                    <ItemsControl ItemsSource="{Binding Objects}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <StackPanel Orientation="Horizontal" Spacing="8" Margin="12,2,0,2">
+                                                                    <fi:SymbolIcon Symbol="ChevronRight" FontSize="12" VerticalAlignment="Center"/>
+                                                                    <TextBlock Text="{Binding Summary}" FontSize="12" VerticalAlignment="Center"/>
+                                                                    <TextBlock Text="{Binding Upn}" FontSize="12"
+                                                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                                               VerticalAlignment="Center"/>
+                                                                </StackPanel>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+
+                                                    <!-- Preflight checks -->
+                                                    <ItemsControl ItemsSource="{Binding PreflightChecks}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <TextBlock FontSize="11"
+                                                                           Margin="12,1,0,1"
+                                                                           TextWrapping="Wrap"
+                                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                                           Text="{Binding Detail, StringFormat='Preflight — {0}'}"/>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
                     </TabItem>
 
                     <!-- Script Preview Tab -->

--- a/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
@@ -123,22 +123,65 @@
                                      Height="4"/>
                     </Grid>
 
-                    <!-- Script Preview / Content -->
+                    <!-- Script Preview / Dry-Run Plan Content -->
                     <Border Grid.Row="2"
                             Classes="sunken"
                             Margin="0,0,0,12">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                                      VerticalScrollBarVisibility="Auto">
-                            <TextBox Text="{Binding StepScript}"
-                                     IsReadOnly="True"
-                                     AcceptsReturn="True"
-                                     TextWrapping="NoWrap"
-                                     FontFamily="{StaticResource CodeFontFamily}"
-                                     FontSize="12"
-                                     BorderThickness="0"
-                                     Padding="16"
-                                     Watermark="Script preview will appear here..."/>
-                        </ScrollViewer>
+                        <Grid>
+                            <!-- PowerShell script preview (default view) -->
+                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                          VerticalScrollBarVisibility="Auto"
+                                          IsVisible="{Binding Plan, Converter={x:Static ObjectConverters.IsNull}}">
+                                <TextBox Text="{Binding StepScript}"
+                                         IsReadOnly="True"
+                                         AcceptsReturn="True"
+                                         TextWrapping="NoWrap"
+                                         FontFamily="{StaticResource CodeFontFamily}"
+                                         FontSize="12"
+                                         BorderThickness="0"
+                                         Padding="16"
+                                         Watermark="Script preview will appear here..."/>
+                            </ScrollViewer>
+
+                            <!-- Dry-run plan (shown once generated) -->
+                            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                          IsVisible="{Binding Plan, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                          Padding="16">
+                                <ItemsControl ItemsSource="{Binding Plan.Entries}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Spacing="8">
+                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                    <fi:SymbolIcon Symbol="CheckmarkCircle" Foreground="Green" IsVisible="{Binding IsValid}"/>
+                                                    <fi:SymbolIcon Symbol="ErrorCircle" Foreground="OrangeRed" IsVisible="{Binding !IsValid}"/>
+                                                    <TextBlock Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                                <ItemsControl ItemsSource="{Binding ValidationErrors}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding}" Foreground="OrangeRed" FontSize="12" TextWrapping="Wrap"/>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                                <ItemsControl ItemsSource="{Binding Objects}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,2,0,2">
+                                                                <fi:SymbolIcon Symbol="ChevronRight" FontSize="12" VerticalAlignment="Center"/>
+                                                                <TextBlock Text="{Binding Summary}" FontSize="12" VerticalAlignment="Center"/>
+                                                                <TextBlock Text="{Binding Upn}" FontSize="12"
+                                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                                           VerticalAlignment="Center"/>
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
 
                     <!-- Step Result -->
@@ -196,6 +239,26 @@
                                     <fi:SymbolIcon Symbol="Next" FontSize="14"/>
                                     <TextBlock Text="Skip" VerticalAlignment="Center"/>
                                 </StackPanel>
+                            </Button>
+
+                            <!-- Dry-run plan preview + export -->
+                            <Button Command="{Binding GeneratePlanCommand}"
+                                    IsEnabled="{Binding !IsBusy}"
+                                    ToolTip.Tip="Preview every object that would be created, with resolved names, UPNs, number and settings — no changes are made.">
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <fi:SymbolIcon Symbol="ClipboardTaskListLtr" FontSize="14"/>
+                                    <TextBlock Text="Dry-Run Plan" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Command="{Binding ExportPlanJsonCommand}"
+                                    IsEnabled="{Binding !IsBusy}"
+                                    ToolTip.Tip="Export the plan as JSON for change-approval workflows.">
+                                <fi:SymbolIcon Symbol="Code" FontSize="14"/>
+                            </Button>
+                            <Button Command="{Binding ExportPlanCsvCommand}"
+                                    IsEnabled="{Binding !IsBusy}"
+                                    ToolTip.Tip="Export the plan as CSV for change-approval workflows.">
+                                <fi:SymbolIcon Symbol="DocumentTable" FontSize="14"/>
                             </Button>
                             <!-- Retry (visible on failure) -->
                             <Button Command="{Binding RetryStepCommand}"

--- a/teams-phonemanager.Tests/DryRunPlanBuilderTests.cs
+++ b/teams-phonemanager.Tests/DryRunPlanBuilderTests.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Services;
+using teams_phonemanager.Services.Interfaces;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Covers <see cref="DryRunPlanBuilder"/>: object enumeration from configuration, create-flow validation,
+    /// intra-plan duplicate preflight, and the guarantee that building a plan performs no PowerShell execution.
+    /// A real <see cref="ValidationService"/> is used so E.164 phone validation runs for real.
+    /// </summary>
+    public class DryRunPlanBuilderTests
+    {
+        private static DryRunPlanBuilder CreateBuilder(out Mock<IValidationService> validationMock)
+        {
+            validationMock = new Mock<IValidationService>();
+            validationMock.Setup(v => v.IsValidPhoneNumber(It.IsAny<string>()))
+                .Returns<string>(s => new ValidationService(new Mock<ISessionManager>().Object).IsValidPhoneNumber(s));
+            return new DryRunPlanBuilder(validationMock.Object);
+        }
+
+        private static PhoneManagerVariables ValidVariables(string customer = "contoso", string group = "hauptnummer", string number = "+41441234567") =>
+            new()
+            {
+                Customer = customer,
+                CustomerGroupName = group,
+                MsFallbackDomain = "@contoso.onmicrosoft.com",
+                RaaAnrName = "haupt",
+                LanguageId = "de-DE",
+                TimeZoneId = "W. Europe Standard Time",
+                UsageLocation = "CH",
+                RaaAnr = number,
+                PhoneNumberType = "DirectRouting"
+            };
+
+        [Fact]
+        public void BuildWizardPlan_ValidConfig_EnumeratesAllExpectedObjects()
+        {
+            var builder = CreateBuilder(out _);
+            var vars = ValidVariables();
+
+            var plan = builder.BuildWizardPlan(vars);
+
+            Assert.Equal("Setup Wizard", plan.Source);
+            Assert.Single(plan.Entries);
+            var entry = plan.Entries[0];
+            Assert.True(entry.IsValid);
+
+            // M365 Group, CQ RA, CQ License, Call Queue, AA RA, AA License, Phone Number, Auto Attendant, Association
+            Assert.Equal(9, entry.Objects.Count);
+            Assert.Contains(entry.Objects, o => o.Type == PlannedObjectType.M365Group && o.DisplayName == "ttgrp-contoso-hauptnummer");
+            Assert.Contains(entry.Objects, o => o.Type == PlannedObjectType.CallQueue && o.DisplayName == "cq-contoso-hauptnummer");
+            Assert.Contains(entry.Objects, o => o.Type == PlannedObjectType.AutoAttendant && o.DisplayName == "aa-contoso-haupt-hauptnummer");
+            Assert.Contains(entry.Objects, o => o.Type == PlannedObjectType.Association);
+
+            var phone = entry.Objects.Single(o => o.Type == PlannedObjectType.PhoneNumber);
+            Assert.Contains(phone.Settings, s => s.Name == "Phone Number" && s.Value == "+41441234567");
+
+            var cqRa = entry.Objects.First(o => o.Type == PlannedObjectType.ResourceAccount);
+            Assert.Equal("racq-contoso-hauptnummer@contoso.onmicrosoft.com", cqRa.Upn);
+        }
+
+        [Fact]
+        public void BuildWizardPlan_MissingPhoneNumber_OmitsPhoneObjectAndReportsValidationError()
+        {
+            var builder = CreateBuilder(out _);
+            var vars = ValidVariables(number: "");
+
+            var plan = builder.BuildWizardPlan(vars);
+            var entry = plan.Entries[0];
+
+            Assert.DoesNotContain(entry.Objects, o => o.Type == PlannedObjectType.PhoneNumber);
+            Assert.Contains(entry.ValidationErrors, e => e.Contains("phone number", System.StringComparison.OrdinalIgnoreCase));
+            Assert.False(entry.IsValid);
+        }
+
+        [Fact]
+        public void BuildWizardPlan_InvalidPhoneNumberFormat_ReportsValidationError()
+        {
+            var builder = CreateBuilder(out _);
+            var vars = ValidVariables(number: "12345"); // not E.164
+
+            var plan = builder.BuildWizardPlan(vars);
+            var entry = plan.Entries[0];
+
+            Assert.Contains(entry.ValidationErrors, e => e.Contains("E.164"));
+            Assert.False(entry.IsValid);
+        }
+
+        [Fact]
+        public void BuildWizardPlan_MissingRequiredFields_ReportsAllErrors()
+        {
+            var builder = CreateBuilder(out _);
+            var vars = new PhoneManagerVariables(); // everything blank
+
+            var plan = builder.BuildWizardPlan(vars);
+            var entry = plan.Entries[0];
+
+            Assert.False(entry.IsValid);
+            Assert.Contains(entry.ValidationErrors, e => e.Contains("Customer"));
+            Assert.Contains(entry.ValidationErrors, e => e.Contains("Usage location"));
+            Assert.Contains(entry.ValidationErrors, e => e.Contains("Language"));
+        }
+
+        [Fact]
+        public void BuildBulkPlan_DuplicateGroupAcrossRows_MarksBothEntriesFailingPreflight()
+        {
+            var builder = CreateBuilder(out _);
+            var entries = new List<IPhoneManagerVariables>
+            {
+                ValidVariables("contoso", "hauptnummer", "+41441234567"),
+                ValidVariables("contoso", "hauptnummer", "+41441239999") // same customer+group => same M365Group + UPNs
+            };
+
+            var plan = builder.BuildBulkPlan(entries);
+
+            Assert.Equal(2, plan.EntryCount);
+            Assert.Equal(0, plan.ValidEntryCount);
+            Assert.All(plan.Entries, e =>
+                Assert.Contains(e.PreflightChecks, c => c.Status == PreflightStatus.Fail && c.Name.Contains("M365 Group")));
+        }
+
+        [Fact]
+        public void BuildBulkPlan_DuplicatePhoneNumberOnly_FailsNumberPreflight()
+        {
+            var builder = CreateBuilder(out _);
+            var entries = new List<IPhoneManagerVariables>
+            {
+                ValidVariables("contoso", "reception", "+41441234567"),
+                ValidVariables("fabrikam", "empfang", "+41441234567") // distinct names, same number
+            };
+
+            var plan = builder.BuildBulkPlan(entries);
+
+            Assert.All(plan.Entries, e =>
+                Assert.Contains(e.PreflightChecks, c => c.Status == PreflightStatus.Fail && c.Name.Contains("Phone number")));
+            // Group/UPN preflight should pass since those differ.
+            Assert.All(plan.Entries, e =>
+                Assert.Contains(e.PreflightChecks, c => c.Status == PreflightStatus.Pass && c.Name.Contains("M365 Group")));
+        }
+
+        [Fact]
+        public void BuildBulkPlan_AllUnique_IsFullyValid()
+        {
+            var builder = CreateBuilder(out _);
+            var entries = new List<IPhoneManagerVariables>
+            {
+                ValidVariables("contoso", "reception", "+41441234567"),
+                ValidVariables("fabrikam", "empfang", "+41441239999")
+            };
+
+            var plan = builder.BuildBulkPlan(entries);
+
+            Assert.True(plan.IsFullyValid);
+            Assert.Equal(2, plan.ValidEntryCount);
+        }
+
+        [Fact]
+        public void BuildBulkPlan_LiveTenantCheck_IsReportedAsNotChecked()
+        {
+            var builder = CreateBuilder(out _);
+            var plan = builder.BuildBulkPlan(new List<IPhoneManagerVariables> { ValidVariables() });
+
+            Assert.Contains(plan.Entries[0].PreflightChecks,
+                c => c.Status == PreflightStatus.NotChecked && c.Name.Contains("Live tenant"));
+        }
+    }
+}

--- a/teams-phonemanager.Tests/DryRunPlanExporterTests.cs
+++ b/teams-phonemanager.Tests/DryRunPlanExporterTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using teams_phonemanager.Planning;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Covers <see cref="DryRunPlanExporter"/>: JSON shape/round-trip and CSV row layout + escaping. Plans are
+    /// constructed directly from Domain value objects so the exporter is exercised in isolation.
+    /// </summary>
+    public class DryRunPlanExporterTests
+    {
+        private static DryRunPlan SamplePlan()
+        {
+            var objects = new List<PlannedObject>
+            {
+                new(PlannedObjectType.M365Group, PlannedAction.Create, "ttgrp-contoso-hauptnummer", null,
+                    new List<PlannedSetting> { new("Name", "ttgrp-contoso-hauptnummer") }),
+                new(PlannedObjectType.ResourceAccount, PlannedAction.Create, "racq-contoso-hauptnummer", "racq-contoso-hauptnummer@contoso.onmicrosoft.com",
+                    new List<PlannedSetting> { new("UPN", "racq-contoso-hauptnummer@contoso.onmicrosoft.com") })
+            };
+            var entry = new DryRunEntry(1, "contoso - hauptnummer", objects,
+                Array.Empty<string>(),
+                new List<PreflightCheck> { new("Live tenant", PreflightStatus.NotChecked, "Not verified") });
+            return new DryRunPlan("Setup Wizard", DateTimeOffset.UtcNow, new List<DryRunEntry> { entry });
+        }
+
+        [Fact]
+        public void ToJson_ProducesParseableDocumentWithEnumNamesAndEntries()
+        {
+            var exporter = new DryRunPlanExporter();
+
+            var json = exporter.ToJson(SamplePlan());
+
+            using var doc = JsonDocument.Parse(json); // must be valid JSON
+            var root = doc.RootElement;
+            Assert.Equal("Setup Wizard", root.GetProperty("Source").GetString());
+            Assert.Equal(1, root.GetProperty("EntryCount").GetInt32());
+            var firstObject = root.GetProperty("Entries")[0].GetProperty("Objects")[0];
+            Assert.Equal("M365Group", firstObject.GetProperty("Type").GetString()); // enum as name, not number
+            Assert.Equal("Create", firstObject.GetProperty("Action").GetString());
+        }
+
+        [Fact]
+        public void ToCsv_EmitsHeaderAndOneRowPerObject()
+        {
+            var exporter = new DryRunPlanExporter();
+
+            var csv = exporter.ToCsv(SamplePlan());
+            var lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.StartsWith("Entry,Label,EntryValid,ObjectType,Action,DisplayName,UPN,Settings,ValidationErrors", lines[0]);
+            Assert.Equal(3, lines.Length); // header + 2 objects
+            Assert.Contains("M365Group", lines[1]);
+            Assert.Contains("ResourceAccount", lines[2]);
+        }
+
+        [Fact]
+        public void ToCsv_EscapesFieldsContainingCommas()
+        {
+            var exporter = new DryRunPlanExporter();
+            var objects = new List<PlannedObject>
+            {
+                new(PlannedObjectType.M365Group, PlannedAction.Create, "Doe, Inc group", null,
+                    new List<PlannedSetting> { new("Name", "Doe, Inc group") })
+            };
+            var entry = new DryRunEntry(1, "Doe, Inc - g", objects, new[] { "err, with comma" }, Array.Empty<PreflightCheck>());
+            var plan = new DryRunPlan("Bulk", DateTimeOffset.UtcNow, new List<DryRunEntry> { entry });
+
+            var csv = exporter.ToCsv(plan);
+
+            // The label and displayName with commas must be wrapped in quotes so columns don't shift.
+            Assert.Contains("\"Doe, Inc - g\"", csv);
+            Assert.Contains("\"Doe, Inc group\"", csv);
+            Assert.Contains("\"err, with comma\"", csv);
+        }
+    }
+}

--- a/teams-phonemanager.Tests/DryRunPreviewViewModelTests.cs
+++ b/teams-phonemanager.Tests/DryRunPreviewViewModelTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using teams_phonemanager.Models;
+using teams_phonemanager.Planning;
+using teams_phonemanager.Services;
+using teams_phonemanager.Services.Interfaces;
+using teams_phonemanager.Services.ScriptBuilders;
+using teams_phonemanager.Tests.TestSupport;
+using teams_phonemanager.ViewModels;
+
+namespace teams_phonemanager.Tests
+{
+    /// <summary>
+    /// Covers the dry-run preview wiring in <see cref="BulkOperationsViewModel"/> and <see cref="WizardViewModel"/>:
+    /// plan generation performs no PowerShell execution (issue #68 zero-mutation guarantee), the bulk execute
+    /// gate blocks on invalid rows unless the operator opts into skipping them, and skipping runs only the
+    /// valid rows.
+    /// </summary>
+    public class DryRunPreviewViewModelTests
+    {
+        private const string Header =
+            "Customer,CustomerGroupName,MsFallbackDomain,RaaAnrName,LanguageId,TimeZoneId,UsageLocation,PhoneNumber,PhoneNumberType,OpeningHours1Start,OpeningHours1End,OpeningHours2Start,OpeningHours2End";
+        private const string ValidRow =
+            "contoso,reception,@contoso.onmicrosoft.com,haupt,de-DE,W. Europe Standard Time,CH,+41441234567,DirectRouting,08:00,12:00,13:00,17:00";
+        private const string InvalidPhoneRow =
+            "fabrikam,empfang,@fabrikam.onmicrosoft.com,haupt,de-DE,W. Europe Standard Time,CH,not-a-number,DirectRouting,08:00,12:00,13:00,17:00";
+
+        private static IPowerShellSanitizationService VerbatimSanitizer()
+        {
+            var mock = new Mock<IPowerShellSanitizationService>();
+            mock.Setup(s => s.SanitizeString(It.IsAny<string>())).Returns<string>(x => x);
+            mock.Setup(s => s.SanitizeIdentifier(It.IsAny<string>())).Returns<string>(x => x);
+            return mock.Object;
+        }
+
+        private static IDryRunPlanBuilder RealPlanBuilder() =>
+            new DryRunPlanBuilder(new ValidationService(new Mock<ISessionManager>().Object));
+
+        private static BulkOperationsViewModel CreateBulkViewModel(ViewModelTestHarness harness) =>
+            new(
+                harness.PowerShellContextService.Object,
+                harness.PowerShellCommandService.Object,
+                harness.LoggingService.Object,
+                harness.SessionManager.Object,
+                harness.NavigationService.Object,
+                harness.ErrorHandlingService.Object,
+                harness.ValidationService.Object,
+                harness.SharedStateService.Object,
+                harness.DialogService.Object,
+                new BulkOperationsScriptBuilder(harness.PowerShellCommandService.Object, VerbatimSanitizer()),
+                RealPlanBuilder(),
+                new DryRunPlanExporter());
+
+        private static WizardViewModel CreateWizardViewModel(ViewModelTestHarness harness) =>
+            new(
+                harness.PowerShellContextService.Object,
+                harness.PowerShellCommandService.Object,
+                harness.LoggingService.Object,
+                harness.SessionManager.Object,
+                harness.NavigationService.Object,
+                harness.ErrorHandlingService.Object,
+                harness.ValidationService.Object,
+                harness.SharedStateService.Object,
+                harness.DialogService.Object,
+                RealPlanBuilder(),
+                new DryRunPlanExporter());
+
+        private static void VerifyNoPowerShellExecuted(ViewModelTestHarness harness) =>
+            harness.PowerShellContextService.Verify(
+                p => p.ExecuteCommandWithDetailsAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<IProgress<PowerShellProgress>?>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+
+        [Fact]
+        public void BulkGeneratePlan_PopulatesPlan_WithoutExecutingPowerShell()
+        {
+            var harness = new ViewModelTestHarness();
+            var vm = CreateBulkViewModel(harness);
+            vm.CsvContent = Header + "\n" + ValidRow;
+            vm.ParseCsvCommand.Execute(null);
+
+            vm.GeneratePlanCommand.Execute(null);
+
+            Assert.NotNull(vm.Plan);
+            Assert.Equal(1, vm.Plan!.EntryCount);
+            Assert.True(vm.Plan.IsFullyValid);
+            VerifyNoPowerShellExecuted(harness);
+        }
+
+        [Fact]
+        public async Task BulkExecuteAll_InvalidRow_SkipOff_BlocksAndDoesNotExecute()
+        {
+            var harness = new ViewModelTestHarness();
+            var vm = CreateBulkViewModel(harness);
+            vm.CsvContent = Header + "\n" + ValidRow + "\n" + InvalidPhoneRow;
+            vm.ParseCsvCommand.Execute(null);
+            vm.SkipInvalidRows = false;
+
+            await vm.ExecuteAllCommand.ExecuteAsync(null);
+
+            Assert.Contains("invalid", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(vm.Plan);
+            Assert.Equal(1, vm.Plan!.InvalidEntryCount);
+            VerifyNoPowerShellExecuted(harness);
+        }
+
+        [Fact]
+        public async Task BulkExecuteAll_InvalidRow_SkipOn_ExecutesValidRowsOnly()
+        {
+            var harness = new ViewModelTestHarness();
+            var vm = CreateBulkViewModel(harness);
+            vm.CsvContent = Header + "\n" + ValidRow + "\n" + InvalidPhoneRow;
+            vm.ParseCsvCommand.Execute(null);
+            vm.SkipInvalidRows = true;
+            harness.SetExecutionResult("SUCCESS: processed");
+
+            await vm.ExecuteAllCommand.ExecuteAsync(null);
+
+            // Only the single valid row runs.
+            Assert.Equal(1, vm.TotalCount);
+            Assert.Equal(1, vm.ProcessedCount);
+            harness.PowerShellContextService.Verify(
+                p => p.ExecuteCommandWithDetailsAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<IProgress<PowerShellProgress>?>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task BulkExecuteAll_AllValid_ExecutesNormally()
+        {
+            var harness = new ViewModelTestHarness();
+            var vm = CreateBulkViewModel(harness);
+            vm.CsvContent = Header + "\n" + ValidRow;
+            vm.ParseCsvCommand.Execute(null);
+            harness.SetExecutionResult("SUCCESS: processed");
+
+            await vm.ExecuteAllCommand.ExecuteAsync(null);
+
+            Assert.Contains("completed successfully", vm.StatusMessage);
+            harness.PowerShellContextService.Verify(
+                p => p.ExecuteCommandWithDetailsAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string>?>(), It.IsAny<IProgress<PowerShellProgress>?>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public void WizardGeneratePlan_PopulatesPlanWithResolvedObjects_WithoutExecutingPowerShell()
+        {
+            var harness = new ViewModelTestHarness();
+            var sharedVars = new PhoneManagerVariables
+            {
+                Customer = "contoso",
+                CustomerGroupName = "reception",
+                MsFallbackDomain = "@contoso.onmicrosoft.com",
+                RaaAnrName = "haupt",
+                LanguageId = "de-DE",
+                TimeZoneId = "W. Europe Standard Time",
+                UsageLocation = "CH",
+                RaaAnr = "+41441234567",
+                PhoneNumberType = "DirectRouting"
+            };
+            harness.SharedStateService.SetupGet(s => s.Variables).Returns(sharedVars);
+            var vm = CreateWizardViewModel(harness);
+
+            vm.GeneratePlanCommand.Execute(null);
+
+            Assert.NotNull(vm.Plan);
+            Assert.Single(vm.Plan!.Entries);
+            Assert.True(vm.Plan.Entries[0].IsValid);
+            Assert.Contains(vm.Plan.Entries[0].Objects, o => o.Type == PlannedObjectType.AutoAttendant);
+            VerifyNoPowerShellExecuted(harness);
+        }
+    }
+}


### PR DESCRIPTION
## What

Implements issue #68: a dry-run preview stage for the setup wizard and bulk CSV operations. Shows exactly what **would** be created/changed before anything executes, and supports exporting the plan for change-approval workflows.

### Highlights
- **Structured plan** (`DryRunPlan`): every object to be created/changed enumerated with resolved name, UPN, number and settings — M365 Group, CQ/AA resource accounts, licenses, phone number, Call Queue, Auto Attendant, and the association.
- **Per-entry validation** of the fields the create flow actually consumes (including E.164 phone validation).
- **Preflight**: intra-plan collision detection (duplicate group / UPN / phone number across CSV rows). Live-tenant checks are honestly reported as `NotChecked` during preview (see judgment call below).
- **Exportable** to JSON or CSV.
- **Bulk execute gate**: nothing runs while any row is invalid, unless the operator enables *Skip invalid rows*, in which case only valid rows execute.

### Safety / constraints honoured
- **No script-builder text or MSAL/Graph auth touched.** The plan derives purely from the same `IPhoneManagerVariables` inputs the frozen builders consume, so execution output stays byte-identical. `git diff` touches only view models, views, DI registration, and new planning files.
- **Zero mutations during preview**, verified by tests through mocked ports — plan generation/export never calls PowerShell, so no `Execute` audit entries are written (a preview is not an operation).
- **Clean Architecture layering**: plan value objects in Domain, plan builder + ports in Application, export writer in Infrastructure, UI in Presentation. Dependency-rule tests pass.
- **Failed-step gating** in the wizard (`CanGoNext` blocks on `StepFailed`) is unchanged.
- Outline-weight FluentIcons only.

### Judgment calls
- **Live-tenant preflight** (collisions/license/number-availability against the tenant) is reported as `NotChecked` rather than implemented, because performing it safely would require new authenticated Graph/PowerShell read paths — in direct tension with the frozen-auth constraint. Intra-plan duplicate detection (a common, real bulk error) is implemented and needs no tenant access. The plan carries a `PreflightCheck` slot so live checks can be added later without a model change.
- **Plan validation** deliberately does not reuse `IValidationService.ValidateVariables`, which additionally requires holiday/greeting-prompt fields set on later pages — reusing it would flag every valid creation entry as invalid. The builder validates only the create-flow fields.

## Tests
Full suite green: **516 passed / 0 failed**. New coverage: `DryRunPlanBuilderTests`, `DryRunPlanExporterTests`, `DryRunPreviewViewModelTests` (object enumeration, validation, duplicate preflight, JSON/CSV export + escaping, no-execution guarantee, bulk skip-invalid gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)