### PR TITLE
feat: read-only tenant dashboard with topology and orphan detection

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -77,6 +77,7 @@ class Program
         services.AddTransient<AutoAttendantScriptBuilder>();
         services.AddTransient<HolidayScriptBuilder>();
         services.AddTransient<ResourceAccountScriptBuilder>();
+        services.AddTransient<DashboardScriptBuilder>();
         services.AddTransient<IDocumentationScriptBuilder, DocumentationScriptBuilder>();
         services.AddTransient<BulkOperationsScriptBuilder>();
 
@@ -86,8 +87,15 @@ class Program
         services.AddTransient<IDryRunPlanBuilder, DryRunPlanBuilder>();
         services.AddTransient<IDryRunPlanExporter, DryRunPlanExporter>();
 
+        // Tenant dashboard (issue #64): read-only topology assembly + session-lifetime cache.
+        // The assembler is a pure transformation; the cache is a singleton so the retrieved snapshot
+        // survives navigation between pages ("results cached in memory for the session").
+        services.AddTransient<ITenantTopologyAssembler, TenantTopologyAssembler>();
+        services.AddSingleton<ITenantTopologyCache, TenantTopologyCache>();
+
         // ViewModels (transient - new instance per navigation)
         services.AddTransient<MainWindowViewModel>();
+        services.AddTransient<DashboardViewModel>();
         services.AddTransient<WelcomeViewModel>();
         services.AddTransient<GetStartedViewModel>();
         services.AddTransient<VariablesViewModel>();

--- a/src/TeamsPhoneManager.Application/Interfaces/IPowerShellCommandService.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/IPowerShellCommandService.cs
@@ -7,6 +7,9 @@ namespace teams_phonemanager.Services.Interfaces;
 /// </summary>
 public interface IPowerShellCommandService
 {
+    // Dashboard (read-only tenant topology, issue #64)
+    string GetRetrieveTenantTopologyCommand();
+
     // Common commands
     string GetCheckModulesCommand();
     string GetCommonSetupScript();

--- a/src/TeamsPhoneManager.Application/Interfaces/ITenantTopologyAssembler.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/ITenantTopologyAssembler.cs
@@ -1,0 +1,16 @@
+using System;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Services.Interfaces
+{
+    /// <summary>
+    /// Assembles a <see cref="TenantTopology"/> from the flattened text output produced by the
+    /// read-only dashboard PowerShell query (see the Infrastructure DashboardScriptBuilder). Pure
+    /// transformation — parses the marker lines, correlates references, and runs orphan detection.
+    /// Kept as an Application port so the assembly logic is unit-testable without a runspace.
+    /// </summary>
+    public interface ITenantTopologyAssembler
+    {
+        TenantTopology Assemble(string? rawOutput, DateTimeOffset retrievedAtUtc);
+    }
+}

--- a/src/TeamsPhoneManager.Application/Interfaces/ITenantTopologyCache.cs
+++ b/src/TeamsPhoneManager.Application/Interfaces/ITenantTopologyCache.cs
@@ -1,0 +1,17 @@
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Services.Interfaces
+{
+    /// <summary>
+    /// Process-lifetime, in-memory cache of the most recently retrieved <see cref="TenantTopology"/>.
+    /// Registered as a singleton so navigating away from and back to the dashboard is instant
+    /// (issue #64: "results cached in memory for the session"). Read-only data only; never persisted.
+    /// </summary>
+    public interface ITenantTopologyCache
+    {
+        bool HasValue { get; }
+        TenantTopology? Current { get; }
+        void Set(TenantTopology topology);
+        void Clear();
+    }
+}

--- a/src/TeamsPhoneManager.Application/Topology/TenantTopologyAssembler.cs
+++ b/src/TeamsPhoneManager.Application/Topology/TenantTopologyAssembler.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using teams_phonemanager.Services.Interfaces;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Parses the marker-line output of the read-only dashboard query into a <see cref="TenantTopology"/>.
+    /// Mirrors the existing "Write-Host PREFIX: a|b|c" convention used across the ScriptBuilders, so the
+    /// parsing is tolerant of extra streams (SUCCESS/INFO/ERROR lines) interleaved by PowerShell.
+    ///
+    /// Line formats (pipe-delimited fields; CSV sub-fields comma-delimited):
+    ///   TOPRA:  DisplayName|UserPrincipalName|ObjectId|PhoneNumber|Kind|AccountEnabled
+    ///   TOPAA:  Name|Identity|LanguageId|TimeZoneId|ResourceAccountIds|HolidayScheduleIds|CallTargetIds
+    ///   TOPCQ:  Name|Identity|RoutingMethod|AgentAlertTime|AgentIds|DistributionListIds|ResourceAccountIds
+    ///   TOPGRP: DisplayName|Id|MailNickname|Description
+    /// </summary>
+    public sealed class TenantTopologyAssembler : ITenantTopologyAssembler
+    {
+        private const string ResourceAccountPrefix = "TOPRA:";
+        private const string AutoAttendantPrefix = "TOPAA:";
+        private const string CallQueuePrefix = "TOPCQ:";
+        private const string GroupPrefix = "TOPGRP:";
+
+        public TenantTopology Assemble(string? rawOutput, DateTimeOffset retrievedAtUtc)
+        {
+            var autoAttendants = new List<TopologyAutoAttendant>();
+            var callQueues = new List<TopologyCallQueue>();
+            var resourceAccounts = new List<TopologyResourceAccount>();
+            var groups = new List<TopologyGroup>();
+
+            if (!string.IsNullOrEmpty(rawOutput))
+            {
+                var lines = rawOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var raw in lines)
+                {
+                    var line = raw.Trim();
+                    if (line.StartsWith(ResourceAccountPrefix, StringComparison.Ordinal))
+                    {
+                        var ra = ParseResourceAccount(Payload(line, ResourceAccountPrefix));
+                        if (ra is not null)
+                        {
+                            resourceAccounts.Add(ra);
+                        }
+                    }
+                    else if (line.StartsWith(AutoAttendantPrefix, StringComparison.Ordinal))
+                    {
+                        var aa = ParseAutoAttendant(Payload(line, AutoAttendantPrefix));
+                        if (aa is not null)
+                        {
+                            autoAttendants.Add(aa);
+                        }
+                    }
+                    else if (line.StartsWith(CallQueuePrefix, StringComparison.Ordinal))
+                    {
+                        var cq = ParseCallQueue(Payload(line, CallQueuePrefix));
+                        if (cq is not null)
+                        {
+                            callQueues.Add(cq);
+                        }
+                    }
+                    else if (line.StartsWith(GroupPrefix, StringComparison.Ordinal))
+                    {
+                        var g = ParseGroup(Payload(line, GroupPrefix));
+                        if (g is not null)
+                        {
+                            groups.Add(g);
+                        }
+                    }
+                }
+            }
+
+            var orphans = TopologyOrphanDetector.Detect(autoAttendants, callQueues, resourceAccounts);
+            return new TenantTopology(autoAttendants, callQueues, resourceAccounts, groups, orphans, retrievedAtUtc);
+        }
+
+        private static string Payload(string line, string prefix) => line.Substring(prefix.Length).Trim();
+
+        private static TopologyResourceAccount? ParseResourceAccount(string payload)
+        {
+            var f = payload.Split('|');
+            if (f.Length < 6)
+            {
+                return null;
+            }
+
+            return new TopologyResourceAccount(
+                f[0].Trim(),
+                f[1].Trim(),
+                f[2].Trim(),
+                NullIfEmpty(f[3].Trim()),
+                ParseKind(f[4].Trim()),
+                ParseBool(f[5].Trim(), defaultValue: true));
+        }
+
+        private static TopologyAutoAttendant? ParseAutoAttendant(string payload)
+        {
+            var f = payload.Split('|');
+            if (f.Length < 4)
+            {
+                return null;
+            }
+
+            return new TopologyAutoAttendant(
+                f[0].Trim(),
+                f[1].Trim(),
+                f[2].Trim(),
+                f[3].Trim(),
+                Csv(f, 4),
+                Csv(f, 5),
+                Csv(f, 6));
+        }
+
+        private static TopologyCallQueue? ParseCallQueue(string payload)
+        {
+            var f = payload.Split('|');
+            if (f.Length < 4)
+            {
+                return null;
+            }
+
+            return new TopologyCallQueue(
+                f[0].Trim(),
+                f[1].Trim(),
+                f[2].Trim(),
+                int.TryParse(f[3].Trim(), out var alert) ? alert : 0,
+                Csv(f, 4),
+                Csv(f, 5),
+                Csv(f, 6));
+        }
+
+        private static TopologyGroup? ParseGroup(string payload)
+        {
+            var f = payload.Split('|');
+            if (f.Length < 2)
+            {
+                return null;
+            }
+
+            return new TopologyGroup(
+                f[0].Trim(),
+                f[1].Trim(),
+                f.Length > 2 ? f[2].Trim() : string.Empty,
+                f.Length > 3 ? f[3].Trim() : string.Empty);
+        }
+
+        private static IReadOnlyList<string> Csv(string[] fields, int index)
+        {
+            if (index >= fields.Length)
+            {
+                return Array.Empty<string>();
+            }
+
+            var value = fields[index].Trim();
+            if (value.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            var parts = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var result = new List<string>(parts.Length);
+            foreach (var p in parts)
+            {
+                var trimmed = p.Trim();
+                if (trimmed.Length > 0)
+                {
+                    result.Add(trimmed);
+                }
+            }
+
+            return result;
+        }
+
+        private static ResourceAccountKind ParseKind(string value) => value switch
+        {
+            "AutoAttendant" => ResourceAccountKind.AutoAttendant,
+            "CallQueue" => ResourceAccountKind.CallQueue,
+            _ => ResourceAccountKind.Unknown,
+        };
+
+        private static bool ParseBool(string value, bool defaultValue)
+            => bool.TryParse(value, out var b) ? b : defaultValue;
+
+        private static string? NullIfEmpty(string value) => value.Length == 0 ? null : value;
+    }
+}

--- a/src/TeamsPhoneManager.Application/Topology/TenantTopologyCache.cs
+++ b/src/TeamsPhoneManager.Application/Topology/TenantTopologyCache.cs
@@ -1,0 +1,23 @@
+using teams_phonemanager.Services.Interfaces;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Services
+{
+    /// <summary>
+    /// Trivial in-memory holder for the last retrieved topology. Registered as a singleton so the
+    /// snapshot survives navigation between pages for the lifetime of the process. Assignment of a
+    /// reference is atomic; the dashboard only ever reads/writes it from the UI thread.
+    /// </summary>
+    public sealed class TenantTopologyCache : ITenantTopologyCache
+    {
+        private TenantTopology? _current;
+
+        public bool HasValue => _current is not null;
+
+        public TenantTopology? Current => _current;
+
+        public void Set(TenantTopology topology) => _current = topology;
+
+        public void Clear() => _current = null;
+    }
+}

--- a/src/TeamsPhoneManager.Domain/ConstantsService.cs
+++ b/src/TeamsPhoneManager.Domain/ConstantsService.cs
@@ -93,6 +93,7 @@ namespace teams_phonemanager.Services
         public static class Pages
         {
             public const string Welcome = "Welcome";
+            public const string Dashboard = "Dashboard";
             public const string GetStarted = "Get Started";
             public const string Variables = "Variables";
             public const string M365Groups = "M365 Groups";

--- a/src/TeamsPhoneManager.Domain/Topology/OrphanFinding.cs
+++ b/src/TeamsPhoneManager.Domain/Topology/OrphanFinding.cs
@@ -1,0 +1,29 @@
+namespace teams_phonemanager.Topology
+{
+    /// <summary>
+    /// The categories of dangling / misconfigured objects the dashboard surfaces. Each maps to one
+    /// acceptance-criteria rule for issue #64.
+    /// </summary>
+    public enum OrphanKind
+    {
+        /// <summary>A resource account that no auto attendant or call queue references.</summary>
+        ResourceAccountUnassociated = 0,
+
+        /// <summary>A call queue with neither direct agents nor any distribution list (no one to ring).</summary>
+        CallQueueWithoutAgents = 1,
+
+        /// <summary>A phone number assigned to a resource account whose Azure AD account is disabled.</summary>
+        PhoneNumberOnDisabledAccount = 2,
+    }
+
+    /// <summary>
+    /// One detected orphan. Pure Domain value; the presentation layer decides how to render it.
+    /// <paramref name="EntityId"/> is a stable identifier (object id / identity) and
+    /// <paramref name="EntityName"/> is the human-readable label.
+    /// </summary>
+    public sealed record OrphanFinding(
+        OrphanKind Kind,
+        string EntityId,
+        string EntityName,
+        string Detail);
+}

--- a/src/TeamsPhoneManager.Domain/Topology/TenantTopology.cs
+++ b/src/TeamsPhoneManager.Domain/Topology/TenantTopology.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace teams_phonemanager.Topology
+{
+    /// <summary>
+    /// An immutable, read-only snapshot of the tenant's telephony topology plus the orphans detected
+    /// within it. Assembled by the Application layer from raw PowerShell output; consumed by the
+    /// Dashboard. Framework-free by design (Clean Architecture Dependency Rule).
+    /// </summary>
+    public sealed class TenantTopology
+    {
+        public TenantTopology(
+            IReadOnlyList<TopologyAutoAttendant> autoAttendants,
+            IReadOnlyList<TopologyCallQueue> callQueues,
+            IReadOnlyList<TopologyResourceAccount> resourceAccounts,
+            IReadOnlyList<TopologyGroup> groups,
+            IReadOnlyList<OrphanFinding> orphans,
+            DateTimeOffset retrievedAtUtc)
+        {
+            AutoAttendants = autoAttendants;
+            CallQueues = callQueues;
+            ResourceAccounts = resourceAccounts;
+            Groups = groups;
+            Orphans = orphans;
+            RetrievedAtUtc = retrievedAtUtc;
+        }
+
+        public IReadOnlyList<TopologyAutoAttendant> AutoAttendants { get; }
+        public IReadOnlyList<TopologyCallQueue> CallQueues { get; }
+        public IReadOnlyList<TopologyResourceAccount> ResourceAccounts { get; }
+        public IReadOnlyList<TopologyGroup> Groups { get; }
+        public IReadOnlyList<OrphanFinding> Orphans { get; }
+        public DateTimeOffset RetrievedAtUtc { get; }
+
+        public static TenantTopology Empty { get; } = new(
+            Array.Empty<TopologyAutoAttendant>(),
+            Array.Empty<TopologyCallQueue>(),
+            Array.Empty<TopologyResourceAccount>(),
+            Array.Empty<TopologyGroup>(),
+            Array.Empty<OrphanFinding>(),
+            DateTimeOffset.MinValue);
+    }
+}

--- a/src/TeamsPhoneManager.Domain/Topology/TopologyModels.cs
+++ b/src/TeamsPhoneManager.Domain/Topology/TopologyModels.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+namespace teams_phonemanager.Topology
+{
+    /// <summary>
+    /// Distinguishes what a Teams resource account (application instance) is wired to, derived from
+    /// its Azure AD application id. Pure Domain value — no framework dependency.
+    /// </summary>
+    public enum ResourceAccountKind
+    {
+        Unknown = 0,
+        AutoAttendant = 1,
+        CallQueue = 2,
+    }
+
+    /// <summary>
+    /// A read-only snapshot of a resource account in the tenant telephony topology.
+    /// <paramref name="ObjectId"/> is the Azure AD object id used to correlate this account with the
+    /// auto attendants / call queues that reference it.
+    /// </summary>
+    public sealed record TopologyResourceAccount(
+        string DisplayName,
+        string UserPrincipalName,
+        string ObjectId,
+        string? PhoneNumber,
+        ResourceAccountKind Kind,
+        bool AccountEnabled)
+    {
+        public bool HasPhoneNumber => !string.IsNullOrWhiteSpace(PhoneNumber);
+    }
+
+    /// <summary>Read-only snapshot of an auto attendant and the ids it relates to.</summary>
+    public sealed record TopologyAutoAttendant(
+        string Name,
+        string Identity,
+        string LanguageId,
+        string TimeZoneId,
+        IReadOnlyList<string> ResourceAccountObjectIds,
+        IReadOnlyList<string> HolidayScheduleIds,
+        IReadOnlyList<string> CallTargetObjectIds);
+
+    /// <summary>Read-only snapshot of a call queue and the ids it relates to.</summary>
+    public sealed record TopologyCallQueue(
+        string Name,
+        string Identity,
+        string RoutingMethod,
+        int AgentAlertTime,
+        IReadOnlyList<string> AgentObjectIds,
+        IReadOnlyList<string> DistributionListIds,
+        IReadOnlyList<string> ResourceAccountObjectIds)
+    {
+        /// <summary>A queue has no way to reach a human when it has neither direct agents nor any group.</summary>
+        public bool HasNoAgents => AgentObjectIds.Count == 0 && DistributionListIds.Count == 0;
+    }
+
+    /// <summary>Read-only snapshot of an M365 group referenced by the topology.</summary>
+    public sealed record TopologyGroup(
+        string DisplayName,
+        string Id,
+        string MailNickname,
+        string Description);
+}

--- a/src/TeamsPhoneManager.Domain/Topology/TopologyOrphanDetector.cs
+++ b/src/TeamsPhoneManager.Domain/Topology/TopologyOrphanDetector.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace teams_phonemanager.Topology
+{
+    /// <summary>
+    /// Pure orphan-detection rules for the tenant dashboard (issue #64). No IO, no framework — fully
+    /// unit-testable. The three rules mirror the acceptance criteria:
+    /// <list type="bullet">
+    /// <item>resource accounts with no AA/CQ association,</item>
+    /// <item>call queues with no agents,</item>
+    /// <item>phone numbers assigned to disabled accounts.</item>
+    /// </list>
+    /// </summary>
+    public static class TopologyOrphanDetector
+    {
+        public static IReadOnlyList<OrphanFinding> Detect(
+            IReadOnlyList<TopologyAutoAttendant> autoAttendants,
+            IReadOnlyList<TopologyCallQueue> callQueues,
+            IReadOnlyList<TopologyResourceAccount> resourceAccounts)
+        {
+            autoAttendants ??= Array.Empty<TopologyAutoAttendant>();
+            callQueues ??= Array.Empty<TopologyCallQueue>();
+            resourceAccounts ??= Array.Empty<TopologyResourceAccount>();
+
+            var findings = new List<OrphanFinding>();
+
+            // Every resource-account object id referenced by any AA or CQ.
+            var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var aa in autoAttendants)
+            {
+                AddAll(referenced, aa.ResourceAccountObjectIds);
+            }
+            foreach (var cq in callQueues)
+            {
+                AddAll(referenced, cq.ResourceAccountObjectIds);
+            }
+
+            // Rule 1: resource account not referenced by any AA or CQ.
+            foreach (var ra in resourceAccounts)
+            {
+                if (string.IsNullOrWhiteSpace(ra.ObjectId) || !referenced.Contains(ra.ObjectId))
+                {
+                    findings.Add(new OrphanFinding(
+                        OrphanKind.ResourceAccountUnassociated,
+                        ra.ObjectId,
+                        DisplayLabel(ra.DisplayName, ra.UserPrincipalName),
+                        "Resource account is not associated with any auto attendant or call queue."));
+                }
+            }
+
+            // Rule 2: call queue with no agents and no groups.
+            foreach (var cq in callQueues)
+            {
+                if (cq.HasNoAgents)
+                {
+                    findings.Add(new OrphanFinding(
+                        OrphanKind.CallQueueWithoutAgents,
+                        cq.Identity,
+                        string.IsNullOrWhiteSpace(cq.Name) ? cq.Identity : cq.Name,
+                        "Call queue has no agents and no distribution lists."));
+                }
+            }
+
+            // Rule 3: phone number assigned to a disabled resource account.
+            foreach (var ra in resourceAccounts)
+            {
+                if (ra.HasPhoneNumber && !ra.AccountEnabled)
+                {
+                    findings.Add(new OrphanFinding(
+                        OrphanKind.PhoneNumberOnDisabledAccount,
+                        ra.ObjectId,
+                        DisplayLabel(ra.DisplayName, ra.UserPrincipalName),
+                        $"Phone number {ra.PhoneNumber} is assigned to a disabled account."));
+                }
+            }
+
+            return findings;
+        }
+
+        private static void AddAll(HashSet<string> set, IReadOnlyList<string>? ids)
+        {
+            if (ids is null)
+            {
+                return;
+            }
+
+            foreach (var id in ids)
+            {
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    set.Add(id);
+                }
+            }
+        }
+
+        private static string DisplayLabel(string? displayName, string? upn)
+            => !string.IsNullOrWhiteSpace(displayName) ? displayName!
+                : (!string.IsNullOrWhiteSpace(upn) ? upn! : "(unknown)");
+    }
+}

--- a/src/TeamsPhoneManager.Infrastructure/PowerShellCommandService.cs
+++ b/src/TeamsPhoneManager.Infrastructure/PowerShellCommandService.cs
@@ -11,20 +11,25 @@ namespace teams_phonemanager.Services
         private readonly AutoAttendantScriptBuilder _autoAttendantBuilder;
         private readonly HolidayScriptBuilder _holidayBuilder;
         private readonly ResourceAccountScriptBuilder _resourceAccountBuilder;
+        private readonly DashboardScriptBuilder _dashboardBuilder;
 
         public PowerShellCommandService(
             CommonScriptBuilder commonBuilder,
             CallQueueScriptBuilder callQueueBuilder,
             AutoAttendantScriptBuilder autoAttendantBuilder,
             HolidayScriptBuilder holidayBuilder,
-            ResourceAccountScriptBuilder resourceAccountBuilder)
+            ResourceAccountScriptBuilder resourceAccountBuilder,
+            DashboardScriptBuilder dashboardBuilder)
         {
             _commonBuilder = commonBuilder;
             _callQueueBuilder = callQueueBuilder;
             _autoAttendantBuilder = autoAttendantBuilder;
             _holidayBuilder = holidayBuilder;
             _resourceAccountBuilder = resourceAccountBuilder;
+            _dashboardBuilder = dashboardBuilder;
         }
+
+        public string GetRetrieveTenantTopologyCommand() => _dashboardBuilder.GetRetrieveTenantTopologyCommand();
 
         public string GetCheckModulesCommand() => _commonBuilder.GetCheckModulesCommand();
         public string GetCommonSetupScript() => _commonBuilder.GetCommonSetupScript();

--- a/src/TeamsPhoneManager.Infrastructure/ScriptBuilders/DashboardScriptBuilder.cs
+++ b/src/TeamsPhoneManager.Infrastructure/ScriptBuilders/DashboardScriptBuilder.cs
@@ -1,0 +1,88 @@
+using teams_phonemanager.Services;
+
+namespace teams_phonemanager.Services.ScriptBuilders
+{
+    /// <summary>
+    /// Builds the single read-only PowerShell query that powers the tenant dashboard (issue #64).
+    /// The script only ever *reads* tenant state (Get-Cs* / Get-Mg*) and never mutates anything, so it
+    /// is safe to run through the standard execution pipeline as an idempotent (throttle-retryable) read.
+    ///
+    /// It emits marker lines that <c>TenantTopologyAssembler</c> parses:
+    ///   TOPRA:  DisplayName|UserPrincipalName|ObjectId|PhoneNumber|Kind|AccountEnabled
+    ///   TOPAA:  Name|Identity|LanguageId|TimeZoneId|ResourceAccountIds|HolidayScheduleIds|CallTargetIds
+    ///   TOPCQ:  Name|Identity|RoutingMethod|AgentAlertTime|AgentIds|DistributionListIds|ResourceAccountIds
+    ///   TOPGRP: DisplayName|Id|MailNickname|Description
+    /// CSV sub-fields are comma-joined id lists. Each section is independently guarded so a failure in
+    /// one query still yields partial topology plus a TOPERR diagnostic line.
+    ///
+    /// This is a NEW read query added to the existing pipeline; it does not modify any existing
+    /// ScriptBuilder text or the MSAL/Graph authentication behaviour.
+    /// </summary>
+    public class DashboardScriptBuilder
+    {
+        public string GetRetrieveTenantTopologyCommand()
+        {
+            return @"
+$ErrorActionPreference = 'Continue'
+
+# --- Resource accounts (application instances): phone numbers + kind + enabled state ---
+try {
+    $appInstances = Get-CsOnlineApplicationInstance -ErrorAction Stop
+    foreach ($ai in $appInstances) {
+        $kind = 'Unknown'
+        if ($ai.ApplicationId -eq '" + ConstantsService.TeamsPhone.CallQueueAppId + @"') { $kind = 'CallQueue' }
+        elseif ($ai.ApplicationId -eq '" + ConstantsService.TeamsPhone.AutoAttendantAppId + @"') { $kind = 'AutoAttendant' }
+
+        $enabled = 'True'
+        try {
+            $usr = Get-CsOnlineUser -Identity $ai.ObjectId -ErrorAction Stop
+            if ($null -ne $usr.AccountEnabled) { $enabled = [string]$usr.AccountEnabled }
+        } catch { }
+
+        Write-Host (""TOPRA: {0}|{1}|{2}|{3}|{4}|{5}"" -f $ai.DisplayName, $ai.UserPrincipalName, $ai.ObjectId, $ai.PhoneNumber, $kind, $enabled)
+    }
+} catch { Write-Host ""TOPERR: ResourceAccounts: $_"" }
+
+# --- Auto attendants: resource accounts, holiday schedules, call-flow targets ---
+try {
+    $autoAttendants = Get-CsAutoAttendant -ErrorAction Stop
+    foreach ($aa in $autoAttendants) {
+        $ras = ($aa.ApplicationInstances -join ',')
+        $holidays = (($aa.CallHandlingAssociations | Where-Object { $_.Type -eq 'Holiday' } | ForEach-Object { $_.ScheduleId }) -join ',')
+        $targets = @()
+        foreach ($cf in $aa.CallFlows) {
+            if ($cf.Menu -and $cf.Menu.MenuOptions) {
+                foreach ($mo in $cf.Menu.MenuOptions) {
+                    if ($mo.CallTarget -and $mo.CallTarget.Id) { $targets += $mo.CallTarget.Id }
+                }
+            }
+        }
+        $targetsCsv = ($targets -join ',')
+        Write-Host (""TOPAA: {0}|{1}|{2}|{3}|{4}|{5}|{6}"" -f $aa.Name, $aa.Identity, $aa.LanguageId, $aa.TimeZoneId, $ras, $holidays, $targetsCsv)
+    }
+} catch { Write-Host ""TOPERR: AutoAttendants: $_"" }
+
+# --- Call queues: agents, distribution lists, resource accounts ---
+try {
+    $callQueues = Get-CsCallQueue -ErrorAction Stop
+    foreach ($cq in $callQueues) {
+        $agents = (($cq.Agents | ForEach-Object { $_.ObjectId }) -join ',')
+        $dls = ($cq.DistributionLists -join ',')
+        $ras = ($cq.ApplicationInstances -join ',')
+        Write-Host (""TOPCQ: {0}|{1}|{2}|{3}|{4}|{5}|{6}"" -f $cq.Name, $cq.Identity, $cq.RoutingMethod, $cq.AgentAlertTime, $agents, $dls, $ras)
+    }
+} catch { Write-Host ""TOPERR: CallQueues: $_"" }
+
+# --- M365 groups ---
+try {
+    $groups = Get-MgGroup -All -ErrorAction Stop
+    foreach ($g in $groups) {
+        Write-Host (""TOPGRP: {0}|{1}|{2}|{3}"" -f $g.DisplayName, $g.Id, $g.MailNickname, $g.Description)
+    }
+} catch { Write-Host ""TOPERR: Groups: $_"" }
+
+Write-Host ""SUCCESS: Tenant topology retrieved""
+";
+        }
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/MainWindow.axaml
+++ b/src/TeamsPhoneManager.Presentation/MainWindow.axaml
@@ -99,6 +99,13 @@
                                 </StackPanel>
                             </ListBoxItem>
 
+                            <ListBoxItem Tag="Dashboard" Classes="nav" AutomationProperties.Name="Dashboard">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="12">
+                                    <fi:SymbolIcon Symbol="DataTrending"/>
+                                    <TextBlock Text="Dashboard" FontSize="13" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </ListBoxItem>
+
                             <ListBoxItem Tag="GetStarted" Classes="nav" AutomationProperties.Name="Get Started">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="12">
                                     <fi:SymbolIcon Symbol="Rocket"/>

--- a/src/TeamsPhoneManager.Presentation/Services/PageViewModelFactory.cs
+++ b/src/TeamsPhoneManager.Presentation/Services/PageViewModelFactory.cs
@@ -33,6 +33,7 @@ namespace teams_phonemanager.Services
             foreach (var page in new[]
             {
                 ConstantsService.Pages.Welcome,
+                ConstantsService.Pages.Dashboard,
                 ConstantsService.Pages.GetStarted,
                 ConstantsService.Pages.Variables,
                 ConstantsService.Pages.M365Groups,
@@ -60,6 +61,7 @@ namespace teams_phonemanager.Services
             return canonical switch
             {
                 ConstantsService.Pages.Welcome => _services.GetRequiredService<WelcomeViewModel>(),
+                ConstantsService.Pages.Dashboard => _services.GetRequiredService<DashboardViewModel>(),
                 ConstantsService.Pages.GetStarted => _services.GetRequiredService<GetStartedViewModel>(),
                 ConstantsService.Pages.Variables => _services.GetRequiredService<VariablesViewModel>(),
                 ConstantsService.Pages.M365Groups => _services.GetRequiredService<M365GroupsViewModel>(),

--- a/src/TeamsPhoneManager.Presentation/ViewModels/DashboardViewModel.cs
+++ b/src/TeamsPhoneManager.Presentation/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using teams_phonemanager.Services;
+using teams_phonemanager.Services.Interfaces;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.ViewModels
+{
+    /// <summary>
+    /// Read-only tenant dashboard (issue #64). Loads the telephony topology through the standard
+    /// PowerShell execution pipeline (so the read is throttle-retried and audited as Kind=Read),
+    /// assembles it via <see cref="ITenantTopologyAssembler"/>, caches it for the session via
+    /// <see cref="ITenantTopologyCache"/>, and exposes search + relationship drill-down + orphans.
+    /// This page never mutates tenant state.
+    /// </summary>
+    public partial class DashboardViewModel : ViewModelBase
+    {
+        private readonly ITenantTopologyAssembler _assembler;
+        private readonly ITenantTopologyCache _cache;
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyAutoAttendant> _autoAttendants = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyCallQueue> _callQueues = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyResourceAccount> _resourceAccounts = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyGroup> _groups = new();
+
+        [ObservableProperty]
+        private ObservableCollection<OrphanFinding> _orphans = new();
+
+        [ObservableProperty]
+        private string _searchText = string.Empty;
+
+        [ObservableProperty]
+        private TopologyAutoAttendant? _selectedAutoAttendant;
+
+        [ObservableProperty]
+        private TopologyCallQueue? _selectedCallQueue;
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyResourceAccount> _selectedAutoAttendantResourceAccounts = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyCallQueue> _selectedAutoAttendantCallQueues = new();
+
+        [ObservableProperty]
+        private ObservableCollection<string> _selectedAutoAttendantHolidayIds = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyResourceAccount> _selectedCallQueueResourceAccounts = new();
+
+        [ObservableProperty]
+        private ObservableCollection<TopologyGroup> _selectedCallQueueGroups = new();
+
+        [ObservableProperty]
+        private ObservableCollection<string> _selectedCallQueueAgentIds = new();
+
+        [ObservableProperty]
+        private DateTimeOffset? _lastRefreshedUtc;
+
+        public DashboardViewModel(
+            IPowerShellContextService powerShellContextService,
+            IPowerShellCommandService powerShellCommandService,
+            ILoggingService loggingService,
+            ISessionManager sessionManager,
+            INavigationService navigationService,
+            IErrorHandlingService errorHandlingService,
+            IValidationService validationService,
+            ITenantTopologyAssembler assembler,
+            ITenantTopologyCache cache,
+            ISharedStateService? sharedStateService = null,
+            IDialogService? dialogService = null,
+            IAuditLog? auditLog = null)
+            : base(powerShellContextService, powerShellCommandService, loggingService,
+                  sessionManager, navigationService, errorHandlingService, validationService,
+                  sharedStateService, dialogService, auditLog)
+        {
+            _assembler = assembler;
+            _cache = cache;
+            _loggingService.Log("Dashboard page loaded", LogLevel.Info);
+
+            // Instant restore from the session cache (issue #64: navigation back is instant).
+            if (_cache.HasValue && _cache.Current is not null)
+            {
+                Populate(_cache.Current);
+            }
+        }
+
+        // Filtered projections used by the UI. Recomputed whenever the source list or search changes.
+        public ObservableCollection<TopologyAutoAttendant> AutoAttendantsView =>
+            new(AutoAttendants.Where(MatchesAutoAttendant));
+
+        public ObservableCollection<TopologyCallQueue> CallQueuesView =>
+            new(CallQueues.Where(MatchesCallQueue));
+
+        public ObservableCollection<TopologyResourceAccount> ResourceAccountsView =>
+            new(ResourceAccounts.Where(MatchesResourceAccount));
+
+        public ObservableCollection<TopologyGroup> GroupsView =>
+            new(Groups.Where(MatchesGroup));
+
+        public bool HasData => AutoAttendants.Count > 0 || CallQueues.Count > 0
+            || ResourceAccounts.Count > 0 || Groups.Count > 0;
+
+        public bool HasOrphans => Orphans.Count > 0;
+
+        public int OrphanCount => Orphans.Count;
+
+        public string LastRefreshedText => LastRefreshedUtc is { } ts
+            ? $"Last refreshed {ts.UtcDateTime:yyyy-MM-dd HH:mm:ss} UTC"
+            : "Not yet loaded";
+
+        /// <summary>Loads from the session cache when present; otherwise performs the first query.</summary>
+        [RelayCommand]
+        private async Task LoadAsync()
+        {
+            if (_cache.HasValue && _cache.Current is not null)
+            {
+                Populate(_cache.Current);
+                return;
+            }
+
+            await RefreshAsync();
+        }
+
+        /// <summary>Re-queries the tenant and refreshes the cache. Idempotent read (audited Kind=Read).</summary>
+        [RelayCommand]
+        private async Task RefreshAsync()
+        {
+            await RunBusyAsync(async () =>
+            {
+                StatusMessage = "Retrieving tenant topology...";
+                var command = _powerShellCommandService.GetRetrieveTenantTopologyCommand();
+                var result = await ExecutePowerShellCommandAsync(command, null, "RetrieveTenantTopology", allowThrottleRetry: true);
+
+                var topology = _assembler.Assemble(result.Value, DateTimeOffset.UtcNow);
+                _cache.Set(topology);
+                Populate(topology);
+
+                StatusMessage = $"Loaded {AutoAttendants.Count} auto attendants, {CallQueues.Count} call queues, "
+                    + $"{ResourceAccounts.Count} resource accounts, {Groups.Count} groups. {OrphanCount} orphan(s).";
+                _loggingService.Log(StatusMessage, LogLevel.Info);
+            }, nameof(RefreshAsync), "Retrieving tenant topology...");
+        }
+
+        [RelayCommand]
+        private void ClearSearch() => SearchText = string.Empty;
+
+        private void Populate(TenantTopology topology)
+        {
+            AutoAttendants = new ObservableCollection<TopologyAutoAttendant>(topology.AutoAttendants);
+            CallQueues = new ObservableCollection<TopologyCallQueue>(topology.CallQueues);
+            ResourceAccounts = new ObservableCollection<TopologyResourceAccount>(topology.ResourceAccounts);
+            Groups = new ObservableCollection<TopologyGroup>(topology.Groups);
+            Orphans = new ObservableCollection<OrphanFinding>(topology.Orphans);
+            LastRefreshedUtc = topology.RetrievedAtUtc == DateTimeOffset.MinValue ? null : topology.RetrievedAtUtc;
+
+            SelectedAutoAttendant = null;
+            SelectedCallQueue = null;
+
+            RaiseViewsChanged();
+            OnPropertyChanged(nameof(HasData));
+            OnPropertyChanged(nameof(HasOrphans));
+            OnPropertyChanged(nameof(OrphanCount));
+        }
+
+        private void RaiseViewsChanged()
+        {
+            OnPropertyChanged(nameof(AutoAttendantsView));
+            OnPropertyChanged(nameof(CallQueuesView));
+            OnPropertyChanged(nameof(ResourceAccountsView));
+            OnPropertyChanged(nameof(GroupsView));
+        }
+
+        partial void OnSearchTextChanged(string value) => RaiseViewsChanged();
+
+        partial void OnLastRefreshedUtcChanged(DateTimeOffset? value)
+            => OnPropertyChanged(nameof(LastRefreshedText));
+
+        partial void OnSelectedAutoAttendantChanged(TopologyAutoAttendant? value)
+        {
+            var ids = value?.ResourceAccountObjectIds ?? (IReadOnlyList<string>)Array.Empty<string>();
+            var targetIds = value?.CallTargetObjectIds ?? (IReadOnlyList<string>)Array.Empty<string>();
+
+            SelectedAutoAttendantResourceAccounts = new ObservableCollection<TopologyResourceAccount>(
+                ResourceAccounts.Where(ra => ids.Contains(ra.ObjectId, StringComparer.OrdinalIgnoreCase)));
+
+            SelectedAutoAttendantHolidayIds = new ObservableCollection<string>(
+                value?.HolidayScheduleIds ?? Enumerable.Empty<string>());
+
+            // AA -> CQ: a call queue is linked when one of its resource accounts is a call-flow target.
+            SelectedAutoAttendantCallQueues = new ObservableCollection<TopologyCallQueue>(
+                CallQueues.Where(cq => cq.ResourceAccountObjectIds
+                    .Any(raId => targetIds.Contains(raId, StringComparer.OrdinalIgnoreCase))));
+        }
+
+        partial void OnSelectedCallQueueChanged(TopologyCallQueue? value)
+        {
+            var raIds = value?.ResourceAccountObjectIds ?? (IReadOnlyList<string>)Array.Empty<string>();
+            var dlIds = value?.DistributionListIds ?? (IReadOnlyList<string>)Array.Empty<string>();
+
+            SelectedCallQueueResourceAccounts = new ObservableCollection<TopologyResourceAccount>(
+                ResourceAccounts.Where(ra => raIds.Contains(ra.ObjectId, StringComparer.OrdinalIgnoreCase)));
+
+            SelectedCallQueueGroups = new ObservableCollection<TopologyGroup>(
+                Groups.Where(g => dlIds.Contains(g.Id, StringComparer.OrdinalIgnoreCase)));
+
+            SelectedCallQueueAgentIds = new ObservableCollection<string>(
+                value?.AgentObjectIds ?? Enumerable.Empty<string>());
+        }
+
+        private bool MatchesAutoAttendant(TopologyAutoAttendant aa)
+        {
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                return true;
+            }
+
+            var q = SearchText.Trim();
+            return Contains(aa.Name, q) || Contains(aa.Identity, q)
+                || Contains(aa.LanguageId, q) || Contains(aa.TimeZoneId, q);
+        }
+
+        private bool MatchesCallQueue(TopologyCallQueue cq)
+        {
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                return true;
+            }
+
+            var q = SearchText.Trim();
+            return Contains(cq.Name, q) || Contains(cq.Identity, q) || Contains(cq.RoutingMethod, q);
+        }
+
+        private bool MatchesResourceAccount(TopologyResourceAccount ra)
+        {
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                return true;
+            }
+
+            var q = SearchText.Trim();
+            return Contains(ra.DisplayName, q) || Contains(ra.UserPrincipalName, q)
+                || Contains(ra.PhoneNumber, q) || Contains(ra.ObjectId, q);
+        }
+
+        private bool MatchesGroup(TopologyGroup g)
+        {
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                return true;
+            }
+
+            var q = SearchText.Trim();
+            return Contains(g.DisplayName, q) || Contains(g.MailNickname, q)
+                || Contains(g.Description, q) || Contains(g.Id, q);
+        }
+
+        private static bool Contains(string? value, string query)
+            => !string.IsNullOrEmpty(value) && value.Contains(query, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
@@ -1,0 +1,302 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             x:Class="teams_phonemanager.Views.DashboardView"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:fi="using:FluentIcons.Avalonia"
+             xmlns:viewmodels="clr-namespace:teams_phonemanager.ViewModels"
+             mc:Ignorable="d"
+             d:DesignHeight="760" d:DesignWidth="1100">
+
+    <Grid>
+        <Border Classes="card" Margin="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header -->
+                <StackPanel Grid.Row="0" Margin="24,24,24,12">
+                    <StackPanel Orientation="Horizontal" Spacing="14">
+                        <Border Classes="icon-badge">
+                            <fi:SymbolIcon Symbol="DataTrending"/>
+                        </Border>
+                        <StackPanel Spacing="4" VerticalAlignment="Center">
+                            <TextBlock Text="Tenant Dashboard" Classes="page-title" Margin="0"/>
+                            <TextBlock Text="A read-only, live view of your telephony topology: auto attendants, call queues, resource accounts, phone numbers and groups — with relationships and orphan detection."
+                                       TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+
+                <!-- Toolbar -->
+                <Border Grid.Row="1" Classes="sunken" Margin="24,0,24,12" Padding="16,12">
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                            <Button Command="{Binding RefreshCommand}" Classes="IconText"
+                                    IsEnabled="{Binding !IsBusy}">
+                                <StackPanel Orientation="Horizontal">
+                                    <fi:SymbolIcon Symbol="ArrowClockwise"/>
+                                    <TextBlock Text="Refresh" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
+                            <Button Command="{Binding CancelOperationCommand}" Classes="IconText"
+                                    IsVisible="{Binding IsCancellable}">
+                                <StackPanel Orientation="Horizontal">
+                                    <fi:SymbolIcon Symbol="Dismiss"/>
+                                    <TextBlock Text="Cancel" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Button>
+                            <TextBox Text="{Binding SearchText}" MinWidth="260"
+                                     Watermark="Search by name, number or UPN"/>
+                            <Button Command="{Binding ClearSearchCommand}" Classes="IconText"
+                                    IsVisible="{Binding SearchText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                <fi:SymbolIcon Symbol="DismissCircle"/>
+                            </Button>
+                        </StackPanel>
+
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" FontSize="12"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="{Binding LastRefreshedText}"/>
+                    </Grid>
+                </Border>
+
+                <!-- Progress + orphan banner -->
+                <StackPanel Grid.Row="2" Margin="24,0,24,12" Spacing="10">
+                    <StackPanel Spacing="6" IsVisible="{Binding IsBusy}">
+                        <ProgressBar Minimum="0" Maximum="100"
+                                     Value="{Binding ProgressValue}"
+                                     IsIndeterminate="{Binding IsProgressIndeterminate}"/>
+                        <TextBlock Text="{Binding StatusMessage}" FontSize="12"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                    </StackPanel>
+
+                    <Border Classes="sunken" Padding="16,12" IsVisible="{Binding HasOrphans}">
+                        <StackPanel Spacing="8">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <fi:SymbolIcon Symbol="Warning" Foreground="{DynamicResource StatusOffBrush}"/>
+                                <TextBlock Text="{Binding OrphanCount, StringFormat='Orphans detected: {0}'}"
+                                           FontWeight="SemiBold"/>
+                            </StackPanel>
+                            <ItemsControl ItemsSource="{Binding Orphans}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid ColumnDefinitions="200,180,*" Margin="0,3">
+                                            <TextBlock Grid.Column="0" FontSize="12" Text="{Binding Kind}"/>
+                                            <TextBlock Grid.Column="1" FontSize="12" Text="{Binding EntityName}"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Grid.Column="2" FontSize="12"
+                                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                       TextWrapping="Wrap" Text="{Binding Detail}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Main content: lists (left) + relationship detail (right) -->
+                <Grid Grid.Row="3" Margin="24,0,24,0" ColumnDefinitions="*,360">
+
+                    <ScrollViewer Grid.Column="0" VerticalScrollBarVisibility="Auto" Margin="0,0,12,0">
+                        <StackPanel Spacing="16">
+
+                            <!-- Auto attendants -->
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="Auto Attendants" FontWeight="SemiBold"/>
+                                <ListBox ItemsSource="{Binding AutoAttendantsView}"
+                                         SelectedItem="{Binding SelectedAutoAttendant}"
+                                         MaxHeight="220">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,140,120">
+                                                <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding LanguageId}" FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                <TextBlock Grid.Column="2" Text="{Binding TimeZoneId}" FontSize="12"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </StackPanel>
+
+                            <!-- Call queues -->
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="Call Queues" FontWeight="SemiBold"/>
+                                <ListBox ItemsSource="{Binding CallQueuesView}"
+                                         SelectedItem="{Binding SelectedCallQueue}"
+                                         MaxHeight="220">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,140,80">
+                                                <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding RoutingMethod}" FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                <TextBlock Grid.Column="2" FontSize="12"
+                                                           Text="{Binding AgentAlertTime, StringFormat='{}{0}s'}"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </StackPanel>
+
+                            <!-- Resource accounts -->
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="Resource Accounts" FontWeight="SemiBold"/>
+                                <ListBox ItemsSource="{Binding ResourceAccountsView}" MaxHeight="220">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,160,110">
+                                                <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding PhoneNumber}" FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                <TextBlock Grid.Column="2" Text="{Binding Kind}" FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </StackPanel>
+
+                            <!-- Groups -->
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="M365 Groups" FontWeight="SemiBold"/>
+                                <ListBox ItemsSource="{Binding GroupsView}" MaxHeight="180">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,220">
+                                                <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding MailNickname}" FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </StackPanel>
+
+                            <!-- Empty state -->
+                            <StackPanel Margin="24,48" Spacing="8" HorizontalAlignment="Center"
+                                        IsVisible="{Binding !HasData}">
+                                <fi:SymbolIcon Symbol="DataTrending" FontSize="32" HorizontalAlignment="Center"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                <TextBlock Text="No topology loaded yet. Connect to Teams and Graph, then press Refresh."
+                                           HorizontalAlignment="Center"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </ScrollViewer>
+
+                    <!-- Relationship detail -->
+                    <Border Grid.Column="1" Classes="sunken" Padding="16">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel Spacing="14">
+                                <TextBlock Text="Relationships" FontWeight="SemiBold"/>
+
+                                <!-- Selected auto attendant -->
+                                <StackPanel Spacing="6" IsVisible="{Binding SelectedAutoAttendant, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <TextBlock Text="{Binding SelectedAutoAttendant.Name, StringFormat='Auto attendant: {0}'}"
+                                               FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="Resource accounts" FontSize="11"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedAutoAttendantResourceAccounts}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock Text="Linked call queues" FontSize="11" Margin="0,6,0,0"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedAutoAttendantCallQueues}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding Name}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock Text="Holiday schedules" FontSize="11" Margin="0,6,0,0"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedAutoAttendantHolidayIds}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+
+                                <!-- Selected call queue -->
+                                <StackPanel Spacing="6" IsVisible="{Binding SelectedCallQueue, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                    <Border Height="1" Background="{DynamicResource HairlineBrush}"/>
+                                    <TextBlock Text="{Binding SelectedCallQueue.Name, StringFormat='Call queue: {0}'}"
+                                               FontWeight="SemiBold" TextTrimming="CharacterEllipsis"/>
+                                    <TextBlock Text="Resource accounts" FontSize="11"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedCallQueueResourceAccounts}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock Text="Agent groups" FontSize="11" Margin="0,6,0,0"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedCallQueueGroups}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                    <TextBlock Text="Agents" FontSize="11" Margin="0,6,0,0"
+                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <ItemsControl ItemsSource="{Binding SelectedCallQueueAgentIds}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontSize="12" Text="{Binding}"/>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+
+                                <TextBlock Text="Select an auto attendant or call queue to see its relationships."
+                                           FontSize="12" TextWrapping="Wrap"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                           IsVisible="{Binding SelectedAutoAttendant, Converter={x:Static ObjectConverters.IsNull}}"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+
+                <!-- Footer -->
+                <Border Grid.Row="4"
+                        Background="{DynamicResource SurfaceSunkenBrush}"
+                        CornerRadius="0,0,12,12"
+                        Padding="24,12"
+                        Margin="0,16,0,0">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                            <fi:SymbolIcon Symbol="Info" FontSize="14"
+                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                            <TextBlock FontSize="12" VerticalAlignment="Center"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                       Text="Read-only view. No changes are made to the tenant."/>
+                        </StackPanel>
+                        <TextBlock Grid.Column="1" FontSize="12" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                   Text="{Binding LastRefreshedText}"/>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/TeamsPhoneManager.Presentation/Views/DashboardView.xaml.cs
+++ b/src/TeamsPhoneManager.Presentation/Views/DashboardView.xaml.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using teams_phonemanager.ViewModels;
+
+namespace teams_phonemanager.Views
+{
+    public partial class DashboardView : UserControl
+    {
+        public DashboardView()
+        {
+            InitializeComponent();
+
+            // Trigger the initial async load on first display. When the session cache already holds a
+            // topology the command returns instantly (issue #64: navigation back is instant); otherwise
+            // it performs the first read-only query with progress + cancellation.
+            Loaded += (_, _) =>
+            {
+                if (DataContext is DashboardViewModel vm && vm.LoadCommand.CanExecute(null))
+                {
+                    vm.LoadCommand.Execute(null);
+                }
+            };
+        }
+    }
+}

--- a/teams-phonemanager.Tests/BulkOperationsSnapshotTests.cs
+++ b/teams-phonemanager.Tests/BulkOperationsSnapshotTests.cs
@@ -54,7 +54,8 @@ namespace teams_phonemanager.Tests
                 new CallQueueScriptBuilder(san),
                 new AutoAttendantScriptBuilder(san),
                 new HolidayScriptBuilder(san),
-                new ResourceAccountScriptBuilder(san));
+                new ResourceAccountScriptBuilder(san),
+                new DashboardScriptBuilder());
 
             var bulk = new BulkOperationsScriptBuilder(facade, san);
 

--- a/teams-phonemanager.Tests/DashboardViewModelTests.cs
+++ b/teams-phonemanager.Tests/DashboardViewModelTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using teams_phonemanager.Audit;
+using teams_phonemanager.Services;
+using teams_phonemanager.Services.Interfaces;
+using teams_phonemanager.Tests.TestSupport;
+using teams_phonemanager.Topology;
+using teams_phonemanager.ViewModels;
+
+namespace teams_phonemanager.Tests
+{
+    public class DashboardViewModelTests
+    {
+        private const string Sample =
+            "TOPRA: RA CQ One|racq-one@contoso.com|ra-obj-1|+41 21 000|CallQueue|True\n" +
+            "TOPRA: RA AA One|raaa-one@contoso.com|ra-obj-2|+41 21 111|AutoAttendant|True\n" +
+            "TOPRA: Disabled RA|racq-dis@contoso.com|ra-obj-4|+41 21 999|CallQueue|False\n" +
+            "TOPAA: Main AA|aa-id-1|en-US|W. Europe Standard Time|ra-obj-2|sched-1|ra-obj-1\n" +
+            "TOPCQ: Support CQ|cq-id-1|Attendant|30|agent-1|grp-1|ra-obj-1\n" +
+            "TOPGRP: Support Group|grp-1|support|Support team\n";
+
+        private static DashboardViewModel Create(
+            ViewModelTestHarness harness,
+            ITenantTopologyCache cache,
+            Mock<IAuditLog>? auditLog = null)
+            => new(
+                harness.PowerShellContextService.Object,
+                harness.PowerShellCommandService.Object,
+                harness.LoggingService.Object,
+                harness.SessionManager.Object,
+                harness.NavigationService.Object,
+                harness.ErrorHandlingService.Object,
+                harness.ValidationService.Object,
+                new TenantTopologyAssembler(),
+                cache,
+                harness.SharedStateService.Object,
+                harness.DialogService.Object,
+                auditLog?.Object);
+
+        [Fact]
+        public async Task Refresh_PopulatesCollectionsAndCache()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var cache = new TenantTopologyCache();
+            var vm = Create(harness, cache);
+
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            Assert.Equal(3, vm.ResourceAccounts.Count);
+            Assert.Single(vm.AutoAttendants);
+            Assert.Single(vm.CallQueues);
+            Assert.Single(vm.Groups);
+            Assert.True(vm.HasData);
+            Assert.True(cache.HasValue);
+            Assert.NotNull(vm.LastRefreshedUtc);
+        }
+
+        [Fact]
+        public async Task Refresh_DetectsAndSurfacesOrphans()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var vm = Create(harness, new TenantTopologyCache());
+
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            Assert.True(vm.HasOrphans);
+            // Disabled RA with a phone number is both unassociated-safe (it IS referenced by the CQ? no)
+            Assert.Contains(vm.Orphans, o => o.Kind == OrphanKind.PhoneNumberOnDisabledAccount);
+        }
+
+        [Fact]
+        public void Constructor_RestoresFromCache_WithoutQuerying()
+        {
+            var cache = new TenantTopologyCache();
+            cache.Set(new TenantTopologyAssembler().Assemble(Sample, DateTimeOffset.UtcNow));
+
+            var harness = new ViewModelTestHarness();
+            var vm = Create(harness, cache);
+
+            // Populated purely from cache in the constructor — no PowerShell execution.
+            Assert.True(vm.HasData);
+            Assert.Single(vm.CallQueues);
+            harness.PowerShellContextService.Verify(
+                p => p.ExecuteCommandWithDetailsAsync(It.IsAny<string>(), It.IsAny<System.Collections.Generic.Dictionary<string, string>?>(),
+                    It.IsAny<IProgress<PowerShellProgress>?>(), It.IsAny<System.Threading.CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task Load_UsesCache_WhenPresent()
+        {
+            var cache = new TenantTopologyCache();
+            cache.Set(new TenantTopologyAssembler().Assemble(Sample, DateTimeOffset.UtcNow));
+            var harness = new ViewModelTestHarness();
+            var vm = Create(harness, cache);
+
+            await vm.LoadCommand.ExecuteAsync(null);
+
+            harness.PowerShellContextService.Verify(
+                p => p.ExecuteCommandWithDetailsAsync(It.IsAny<string>(), It.IsAny<System.Collections.Generic.Dictionary<string, string>?>(),
+                    It.IsAny<IProgress<PowerShellProgress>?>(), It.IsAny<System.Threading.CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task Load_Queries_WhenCacheEmpty()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var vm = Create(harness, new TenantTopologyCache());
+
+            await vm.LoadCommand.ExecuteAsync(null);
+
+            Assert.True(vm.HasData);
+        }
+
+        [Fact]
+        public async Task Search_FiltersAcrossObjectTypes()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var vm = Create(harness, new TenantTopologyCache());
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            vm.SearchText = "raaa-one";
+            Assert.Single(vm.ResourceAccountsView);
+            Assert.Equal("ra-obj-2", vm.ResourceAccountsView[0].ObjectId);
+
+            vm.SearchText = "+41 21 999";
+            Assert.Single(vm.ResourceAccountsView);
+            Assert.Equal("ra-obj-4", vm.ResourceAccountsView[0].ObjectId);
+
+            vm.SearchText = "Support";
+            Assert.Single(vm.CallQueuesView);
+            Assert.Single(vm.GroupsView);
+
+            vm.ClearSearchCommand.Execute(null);
+            Assert.Equal(3, vm.ResourceAccountsView.Count);
+        }
+
+        [Fact]
+        public async Task SelectingAutoAttendant_ResolvesRelationships()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var vm = Create(harness, new TenantTopologyCache());
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            vm.SelectedAutoAttendant = vm.AutoAttendants.Single();
+
+            Assert.Single(vm.SelectedAutoAttendantResourceAccounts);
+            Assert.Equal("ra-obj-2", vm.SelectedAutoAttendantResourceAccounts[0].ObjectId);
+            // Call target ra-obj-1 belongs to Support CQ -> linked queue.
+            Assert.Single(vm.SelectedAutoAttendantCallQueues);
+            Assert.Equal("cq-id-1", vm.SelectedAutoAttendantCallQueues[0].Identity);
+            Assert.Equal(new[] { "sched-1" }, vm.SelectedAutoAttendantHolidayIds);
+        }
+
+        [Fact]
+        public async Task SelectingCallQueue_ResolvesAgentsAndGroups()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var vm = Create(harness, new TenantTopologyCache());
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            vm.SelectedCallQueue = vm.CallQueues.Single();
+
+            Assert.Single(vm.SelectedCallQueueGroups);
+            Assert.Equal("grp-1", vm.SelectedCallQueueGroups[0].Id);
+            Assert.Equal(new[] { "agent-1" }, vm.SelectedCallQueueAgentIds);
+            Assert.Single(vm.SelectedCallQueueResourceAccounts);
+        }
+
+        [Fact]
+        public async Task Refresh_IsAuditedAsReadOperation()
+        {
+            var harness = new ViewModelTestHarness();
+            harness.SetExecutionResult(Sample);
+            var auditLog = new Mock<IAuditLog>();
+            var vm = Create(harness, new TenantTopologyCache(), auditLog);
+
+            await vm.RefreshCommand.ExecuteAsync(null);
+
+            auditLog.Verify(a => a.Append(It.Is<AuditRecord>(r => r.Kind == AuditKind.Read)), Times.AtLeastOnce);
+        }
+    }
+}

--- a/teams-phonemanager.Tests/TenantTopologyAssemblerTests.cs
+++ b/teams-phonemanager.Tests/TenantTopologyAssemblerTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using teams_phonemanager.Services;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Tests
+{
+    public class TenantTopologyAssemblerTests
+    {
+        private const string Sample =
+            "SUCCESS: connected\n" +
+            "TOPRA: RA CQ One|racq-one@contoso.com|ra-obj-1|+41 21 000|CallQueue|True\n" +
+            "TOPRA: RA AA One|raaa-one@contoso.com|ra-obj-2|+41 21 111|AutoAttendant|True\n" +
+            "TOPRA: Orphan RA|racq-orphan@contoso.com|ra-obj-3||CallQueue|True\n" +
+            "TOPRA: Disabled RA|racq-dis@contoso.com|ra-obj-4|+41 21 999|CallQueue|False\n" +
+            "TOPAA: Main AA|aa-id-1|en-US|W. Europe Standard Time|ra-obj-2|sched-1,sched-2|ra-obj-1\n" +
+            "TOPCQ: Support CQ|cq-id-1|Attendant|30|agent-1|grp-1|ra-obj-1\n" +
+            "TOPCQ: Empty CQ|cq-id-2|Serial|20|||ra-obj-9\n" +
+            "TOPGRP: Support Group|grp-1|support|Support team\n" +
+            "SUCCESS: Tenant topology retrieved\n";
+
+        private readonly TenantTopologyAssembler _sut = new();
+
+        [Fact]
+        public void Assemble_ParsesEveryObjectType()
+        {
+            var t = _sut.Assemble(Sample, DateTimeOffset.UtcNow);
+
+            Assert.Equal(4, t.ResourceAccounts.Count);
+            Assert.Single(t.AutoAttendants);
+            Assert.Equal(2, t.CallQueues.Count);
+            Assert.Single(t.Groups);
+        }
+
+        [Fact]
+        public void Assemble_MapsResourceAccountFields()
+        {
+            var t = _sut.Assemble(Sample, DateTimeOffset.UtcNow);
+
+            var ra = t.ResourceAccounts.Single(r => r.ObjectId == "ra-obj-1");
+            Assert.Equal("RA CQ One", ra.DisplayName);
+            Assert.Equal("racq-one@contoso.com", ra.UserPrincipalName);
+            Assert.Equal("+41 21 000", ra.PhoneNumber);
+            Assert.Equal(ResourceAccountKind.CallQueue, ra.Kind);
+            Assert.True(ra.AccountEnabled);
+
+            var disabled = t.ResourceAccounts.Single(r => r.ObjectId == "ra-obj-4");
+            Assert.False(disabled.AccountEnabled);
+
+            var orphan = t.ResourceAccounts.Single(r => r.ObjectId == "ra-obj-3");
+            Assert.Null(orphan.PhoneNumber);
+            Assert.False(orphan.HasPhoneNumber);
+        }
+
+        [Fact]
+        public void Assemble_ParsesCsvSubfields()
+        {
+            var t = _sut.Assemble(Sample, DateTimeOffset.UtcNow);
+
+            var aa = t.AutoAttendants.Single();
+            Assert.Equal(new[] { "ra-obj-2" }, aa.ResourceAccountObjectIds);
+            Assert.Equal(new[] { "sched-1", "sched-2" }, aa.HolidayScheduleIds);
+            Assert.Equal(new[] { "ra-obj-1" }, aa.CallTargetObjectIds);
+
+            var cq = t.CallQueues.Single(c => c.Identity == "cq-id-1");
+            Assert.Equal(30, cq.AgentAlertTime);
+            Assert.Equal(new[] { "agent-1" }, cq.AgentObjectIds);
+            Assert.Equal(new[] { "grp-1" }, cq.DistributionListIds);
+        }
+
+        [Fact]
+        public void Assemble_EmptyCsvFields_YieldEmptyLists()
+        {
+            var t = _sut.Assemble(Sample, DateTimeOffset.UtcNow);
+
+            var empty = t.CallQueues.Single(c => c.Identity == "cq-id-2");
+            Assert.Empty(empty.AgentObjectIds);
+            Assert.Empty(empty.DistributionListIds);
+            Assert.True(empty.HasNoAgents);
+        }
+
+        [Fact]
+        public void Assemble_RunsOrphanDetection()
+        {
+            var t = _sut.Assemble(Sample, DateTimeOffset.UtcNow);
+
+            // ra-obj-3 and ra-obj-4 are unassociated (referenced set is ra-obj-2, ra-obj-1, ra-obj-9).
+            Assert.Equal(2, t.Orphans.Count(o => o.Kind == OrphanKind.ResourceAccountUnassociated));
+            // Empty CQ has no agents.
+            Assert.Contains(t.Orphans, o => o.Kind == OrphanKind.CallQueueWithoutAgents && o.EntityId == "cq-id-2");
+            // Disabled RA with a phone number.
+            Assert.Contains(t.Orphans, o => o.Kind == OrphanKind.PhoneNumberOnDisabledAccount && o.EntityId == "ra-obj-4");
+        }
+
+        [Fact]
+        public void Assemble_IgnoresDiagnosticAndUnknownLines()
+        {
+            var t = _sut.Assemble("TOPERR: Groups: boom\nrandom noise\nTOPGRP: G|g1|nick|desc\n", DateTimeOffset.UtcNow);
+
+            Assert.Empty(t.AutoAttendants);
+            Assert.Single(t.Groups);
+        }
+
+        [Fact]
+        public void Assemble_NullOrEmpty_ReturnsEmptyTopology()
+        {
+            var t = _sut.Assemble(null, DateTimeOffset.UtcNow);
+            Assert.Empty(t.ResourceAccounts);
+            Assert.Empty(t.Orphans);
+        }
+
+        [Fact]
+        public void Assemble_HandlesCrlfLineEndings()
+        {
+            var t = _sut.Assemble("TOPGRP: G|g1|nick|desc\r\nTOPGRP: H|g2|nick2|desc2\r\n", DateTimeOffset.UtcNow);
+            Assert.Equal(2, t.Groups.Count);
+        }
+
+        [Fact]
+        public void Assemble_PreservesRetrievedTimestamp()
+        {
+            var when = DateTimeOffset.UtcNow;
+            var t = _sut.Assemble(Sample, when);
+            Assert.Equal(when, t.RetrievedAtUtc);
+        }
+    }
+}

--- a/teams-phonemanager.Tests/TopologyOrphanDetectorTests.cs
+++ b/teams-phonemanager.Tests/TopologyOrphanDetectorTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using teams_phonemanager.Topology;
+
+namespace teams_phonemanager.Tests
+{
+    public class TopologyOrphanDetectorTests
+    {
+        private static TopologyResourceAccount Ra(
+            string objectId, string? phone = null, bool enabled = true,
+            ResourceAccountKind kind = ResourceAccountKind.CallQueue)
+            => new($"RA {objectId}", $"{objectId}@contoso.com", objectId, phone, kind, enabled);
+
+        private static TopologyAutoAttendant Aa(string id, params string[] raIds)
+            => new($"AA {id}", id, "en-US", "UTC", raIds, Array.Empty<string>(), Array.Empty<string>());
+
+        private static TopologyCallQueue Cq(string id, string[]? agents = null, string[]? dls = null, string[]? ras = null)
+            => new($"CQ {id}", id, "Attendant", 30,
+                agents ?? Array.Empty<string>(), dls ?? Array.Empty<string>(), ras ?? Array.Empty<string>());
+
+        [Fact]
+        public void UnassociatedResourceAccount_IsFlagged()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                new[] { Aa("aa1", "ra-used") },
+                Array.Empty<TopologyCallQueue>(),
+                new[] { Ra("ra-used"), Ra("ra-orphan") });
+
+            var orphans = findings.Where(f => f.Kind == OrphanKind.ResourceAccountUnassociated).ToList();
+            Assert.Single(orphans);
+            Assert.Equal("ra-orphan", orphans[0].EntityId);
+        }
+
+        [Fact]
+        public void ResourceAccount_ReferencedByCallQueue_IsNotFlagged()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                Array.Empty<TopologyAutoAttendant>(),
+                new[] { Cq("cq1", agents: new[] { "a" }, ras: new[] { "ra-used" }) },
+                new[] { Ra("ra-used") });
+
+            Assert.DoesNotContain(findings, f => f.Kind == OrphanKind.ResourceAccountUnassociated);
+        }
+
+        [Fact]
+        public void CallQueueWithoutAgentsOrGroups_IsFlagged()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                Array.Empty<TopologyAutoAttendant>(),
+                new[] { Cq("cq-empty"), Cq("cq-ok", agents: new[] { "agent1" }) },
+                Array.Empty<TopologyResourceAccount>());
+
+            var orphans = findings.Where(f => f.Kind == OrphanKind.CallQueueWithoutAgents).ToList();
+            Assert.Single(orphans);
+            Assert.Equal("cq-empty", orphans[0].EntityId);
+        }
+
+        [Fact]
+        public void CallQueueWithOnlyDistributionList_IsNotFlaggedAsNoAgents()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                Array.Empty<TopologyAutoAttendant>(),
+                new[] { Cq("cq1", dls: new[] { "group-1" }) },
+                Array.Empty<TopologyResourceAccount>());
+
+            Assert.DoesNotContain(findings, f => f.Kind == OrphanKind.CallQueueWithoutAgents);
+        }
+
+        [Fact]
+        public void PhoneNumberOnDisabledAccount_IsFlagged()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                Array.Empty<TopologyAutoAttendant>(),
+                new[] { Cq("cq1", ras: new[] { "ra-dis", "ra-ok" }) },
+                new[]
+                {
+                    Ra("ra-dis", phone: "+41000", enabled: false),
+                    Ra("ra-ok", phone: "+41111", enabled: true),
+                });
+
+            var orphans = findings.Where(f => f.Kind == OrphanKind.PhoneNumberOnDisabledAccount).ToList();
+            Assert.Single(orphans);
+            Assert.Equal("ra-dis", orphans[0].EntityId);
+            Assert.Contains("+41000", orphans[0].Detail);
+        }
+
+        [Fact]
+        public void DisabledAccountWithoutPhoneNumber_IsNotFlaggedForDisabledPhone()
+        {
+            var findings = TopologyOrphanDetector.Detect(
+                Array.Empty<TopologyAutoAttendant>(),
+                new[] { Cq("cq1", ras: new[] { "ra-dis" }) },
+                new[] { Ra("ra-dis", phone: null, enabled: false) });
+
+            Assert.DoesNotContain(findings, f => f.Kind == OrphanKind.PhoneNumberOnDisabledAccount);
+        }
+
+        [Fact]
+        public void Detect_ToleratesNullCollections()
+        {
+            var findings = TopologyOrphanDetector.Detect(null!, null!, null!);
+            Assert.Empty(findings);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #64

## What
Adds a read-only **Dashboard** page that loads and displays the tenant's telephony topology — auto attendants, call queues, resource accounts, assigned phone numbers and M365 groups — with relationship drill-down, free-text search/filter, and orphan detection. Read-only in v1: this page never mutates tenant state.

## How it works
- **Data retrieval** goes through the existing execution pipeline. A new `DashboardScriptBuilder` adds a single read-only `Get-CsOnlineApplicationInstance` / `Get-CsAutoAttendant` / `Get-CsCallQueue` / `Get-MgGroup` query that emits marker lines (same convention as the existing retrieve commands). **No existing ScriptBuilder text and no MSAL/Graph auth behaviour is changed.** Reads run via `ExecutePowerShellCommandAsync(..., allowThrottleRetry: true)`, so they are idempotent/throttle-retried and automatically audited as `Kind=Read` (#67).
- **Clean Architecture layering:** topology models + orphan rules live in Domain (framework-free); the assembler (pure parse → assemble → detect) and a singleton session cache are Application ports; the query is Infrastructure; the page + VM are Presentation; DI is in `Program.cs`. The dependency-rule tests still pass.

## Acceptance criteria
- Lists all auto attendants, call queues, resource accounts and assigned phone numbers with key properties.
- Relationship view: selecting an auto attendant shows its resource accounts, linked call queues and holiday schedules; selecting a call queue shows its agent group, members and resource accounts.
- Free-text search/filter across all object types (name, number, UPN, identity).
- Orphan detection surfaced visually: resource accounts with no association, call queues with no agents, phone numbers assigned to disabled accounts.
- Async load with progress + cancellation; Refresh re-queries; last-refreshed timestamp shown.
- Results cached in memory for the session (singleton cache) so navigating back is instant.
- Read-only: no mutation.

## Tests
New xUnit coverage for orphan-detection rules, topology assembly/parsing (incl. CSV sub-fields, CRLF, diagnostics), and the ViewModel (refresh populates + caches, cache restore without querying, search filtering, relationship resolution, and audit `Kind=Read`). Full suite: **541 passing**.

## Judgment calls / v1 limitations
- **AA → linked call queues** is inferred by matching an auto attendant's call-flow target object ids against each call queue's resource-account object ids (no direct link field exists in the API). Best-effort.
- **Holiday schedules** are shown by schedule id (name resolution would need an extra `Get-CsOnlineSchedule` round-trip).
- **Account-enabled** state for the disabled-number orphan rule is read per resource account via `Get-CsOnlineUser`, guarded so a lookup failure defaults to enabled.
- The consolidated query and marker parsing were exercised with synthetic fixtures; live-tenant behaviour was not run here (no tenant credentials in this environment). The parsing/assembly/detection logic is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)