### PR TITLE
fix: text overflow and alignment issues in history, dashboard, and dry-run UI

### DIFF
--- a/src/TeamsPhoneManager.Presentation/Views/AutoAttendantsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/AutoAttendantsView.axaml
@@ -18,7 +18,11 @@
     </UserControl.Resources>
 
     <UserControl.Styles>
-        <!-- Local styles removed, using App.axaml styles -->
+        <!-- Ellipsis-trim long values in list grids so rows stay distinguishable and the
+             rightmost column's text can never disappear under the vertical scrollbar. -->
+        <Style Selector="DataGridCell TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
     </UserControl.Styles>
 
     <Grid>

--- a/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
@@ -15,6 +15,13 @@
         <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
     </UserControl.Resources>
 
+    <UserControl.Styles>
+        <!-- Ellipsis-trim long identifiers in the Parsed Entries grid so rows stay distinguishable. -->
+        <Style Selector="DataGridCell TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
+    </UserControl.Styles>
+
     <Grid>
         <Border Classes="card" Margin="0">
             <Grid>

--- a/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/BulkOperationsView.axaml
@@ -25,11 +25,11 @@
 
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Margin="24,24,24,16">
-                    <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,0,0,14">
-                        <Border Classes="icon-badge">
+                    <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,14">
+                        <Border Grid.Column="0" Classes="icon-badge" VerticalAlignment="Top">
                             <fi:SymbolIcon Symbol="TableMultiple"/>
                         </Border>
-                        <StackPanel Spacing="4" VerticalAlignment="Center">
+                        <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" Margin="14,0,0,0">
                             <TextBlock Text="Bulk Operations"
                                      Classes="page-title"
                                      Margin="0"/>
@@ -37,10 +37,15 @@
                                      TextWrapping="Wrap"
                                      Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                         </StackPanel>
-                    </StackPanel>
+                    </Grid>
 
-                    <!-- Action Buttons -->
-                    <StackPanel Orientation="Horizontal" Spacing="8">
+                    <!-- Action Buttons — wrap so no button is clipped at narrow widths. -->
+                    <WrapPanel Orientation="Horizontal">
+                        <WrapPanel.Styles>
+                            <Style Selector="WrapPanel > Button">
+                                <Setter Property="Margin" Value="0,0,8,8"/>
+                            </Style>
+                        </WrapPanel.Styles>
                         <Button Command="{Binding ExportTemplateFileCommand}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
                                 <fi:SymbolIcon Symbol="ArrowDownload"/>
@@ -85,10 +90,10 @@
                                 <TextBlock Text="Execute All" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
-                    </StackPanel>
+                    </WrapPanel>
 
                     <!-- Dry-run plan export + safety toggle -->
-                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,8,0,0">
+                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,0">
                         <Button Command="{Binding ExportPlanJsonCommand}" IsEnabled="{Binding !IsBusy}" Classes="IconText">
                             <StackPanel Orientation="Horizontal">
                                 <fi:SymbolIcon Symbol="Code"/>
@@ -187,18 +192,22 @@
                                         <DataTemplate>
                                             <Border Classes="card" Margin="0,0,0,10" Padding="14">
                                                 <StackPanel Spacing="8">
-                                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                                        <fi:SymbolIcon Symbol="CheckmarkCircle"
-                                                                       Foreground="Green"
-                                                                       IsVisible="{Binding IsValid}"/>
-                                                        <fi:SymbolIcon Symbol="ErrorCircle"
-                                                                       Foreground="OrangeRed"
-                                                                       IsVisible="{Binding !IsValid}"/>
-                                                        <TextBlock Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                                        <TextBlock Text="{Binding RowNumber, StringFormat='Row {0}'}"
+                                                    <Grid ColumnDefinitions="Auto,*,Auto">
+                                                        <Panel Grid.Column="0" VerticalAlignment="Top" Margin="0,1,8,0">
+                                                            <fi:SymbolIcon Symbol="CheckmarkCircle"
+                                                                           Foreground="Green"
+                                                                           IsVisible="{Binding IsValid}"/>
+                                                            <fi:SymbolIcon Symbol="ErrorCircle"
+                                                                           Foreground="OrangeRed"
+                                                                           IsVisible="{Binding !IsValid}"/>
+                                                        </Panel>
+                                                        <TextBlock Grid.Column="1" Text="{Binding Label}" FontWeight="SemiBold"
+                                                                   TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                                        <TextBlock Grid.Column="2" Text="{Binding RowNumber, StringFormat='Row {0}'}"
+                                                                   Margin="12,0,0,0"
                                                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                                                    VerticalAlignment="Center"/>
-                                                    </StackPanel>
+                                                    </Grid>
 
                                                     <!-- Validation errors -->
                                                     <ItemsControl ItemsSource="{Binding ValidationErrors}"
@@ -214,13 +223,17 @@
                                                     <ItemsControl ItemsSource="{Binding Objects}">
                                                         <ItemsControl.ItemTemplate>
                                                             <DataTemplate>
-                                                                <StackPanel Orientation="Horizontal" Spacing="8" Margin="12,2,0,2">
-                                                                    <fi:SymbolIcon Symbol="ChevronRight" FontSize="12" VerticalAlignment="Center"/>
-                                                                    <TextBlock Text="{Binding Summary}" FontSize="12" VerticalAlignment="Center"/>
-                                                                    <TextBlock Text="{Binding Upn}" FontSize="12"
-                                                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                                               VerticalAlignment="Center"/>
-                                                                </StackPanel>
+                                                                <Grid ColumnDefinitions="Auto,*" Margin="12,2,0,2">
+                                                                    <fi:SymbolIcon Grid.Column="0" Symbol="ChevronRight" FontSize="12"
+                                                                                   VerticalAlignment="Top" Margin="0,2,8,0"/>
+                                                                    <StackPanel Grid.Column="1" Spacing="1">
+                                                                        <TextBlock Text="{Binding Summary}" FontSize="12" TextWrapping="Wrap"/>
+                                                                        <TextBlock Text="{Binding Upn}" FontSize="12"
+                                                                                   TextWrapping="Wrap"
+                                                                                   IsVisible="{Binding Upn, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                    </StackPanel>
+                                                                </Grid>
                                                             </DataTemplate>
                                                         </ItemsControl.ItemTemplate>
                                                     </ItemsControl>

--- a/src/TeamsPhoneManager.Presentation/Views/CallQueuesView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/CallQueuesView.axaml
@@ -18,7 +18,11 @@
     </UserControl.Resources>
 
     <UserControl.Styles>
-        <!-- Local styles removed, using App.axaml styles -->
+        <!-- Ellipsis-trim long values in list grids so rows stay distinguishable and the
+             rightmost column's text can never disappear under the vertical scrollbar. -->
+        <Style Selector="DataGridCell TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
     </UserControl.Styles>
 
     <Border Classes="card" Margin="0">

--- a/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
@@ -121,17 +121,13 @@
                                          MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" MinWidth="120"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
+                                            <Grid Margin="0,0,10,0" ColumnDefinitions="1.9*,Auto,1.3*">
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Grid.Column="1" Text="{Binding LanguageId}" FontSize="12" Margin="10,0,0,0"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                                 <TextBlock Grid.Column="2" Text="{Binding TimeZoneId}" FontSize="12" Margin="10,0,0,0"
-                                                           MaxWidth="150" TextTrimming="CharacterEllipsis"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -147,14 +143,10 @@
                                          MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" MinWidth="120"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
+                                            <Grid Margin="0,0,10,0" ColumnDefinitions="*,Auto,Auto">
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Grid.Column="1" Text="{Binding RoutingMethod}" FontSize="12" Margin="10,0,0,0"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                                 <TextBlock Grid.Column="2" FontSize="12" Margin="10,0,0,0"
                                                            Text="{Binding AgentAlertTime, StringFormat='{}{0}s'}"
@@ -171,16 +163,13 @@
                                 <ListBox ItemsSource="{Binding ResourceAccountsView}" MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" MinWidth="120"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
+                                            <Grid Margin="0,0,10,0" ColumnDefinitions="1.9*,1.3*,Auto">
                                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Grid.Column="1" Text="{Binding PhoneNumber}" FontSize="12" Margin="10,0,0,0"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                                 <TextBlock Grid.Column="2" Text="{Binding Kind}" FontSize="12" Margin="10,0,0,0"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -194,14 +183,10 @@
                                 <ListBox ItemsSource="{Binding GroupsView}" MaxHeight="180">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" MinWidth="120"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
+                                            <Grid Margin="0,0,10,0" ColumnDefinitions="1.9*,1.3*">
                                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Grid.Column="1" Text="{Binding MailNickname}" FontSize="12" Margin="10,0,0,0"
-                                                           MaxWidth="220" TextTrimming="CharacterEllipsis"
+                                                           TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>

--- a/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
@@ -8,6 +8,14 @@
              mc:Ignorable="d"
              d:DesignHeight="760" d:DesignWidth="1100">
 
+    <UserControl.Styles>
+        <!-- Stretch list rows to full width so the star-sized Name column fills the row instead of
+             sizing to content (which would leave the secondary columns floating left). -->
+        <Style Selector="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        </Style>
+    </UserControl.Styles>
+
     <Grid>
         <Border Classes="card" Margin="0">
             <Grid>
@@ -20,19 +28,17 @@
                 </Grid.RowDefinitions>
 
                 <!-- Header -->
-                <StackPanel Grid.Row="0" Margin="24,24,24,12">
-                    <StackPanel Orientation="Horizontal" Spacing="14">
-                        <Border Classes="icon-badge">
-                            <fi:SymbolIcon Symbol="DataTrending"/>
-                        </Border>
-                        <StackPanel Spacing="4" VerticalAlignment="Center">
-                            <TextBlock Text="Tenant Dashboard" Classes="page-title" Margin="0"/>
-                            <TextBlock Text="A read-only, live view of your telephony topology: auto attendants, call queues, resource accounts, phone numbers and groups — with relationships and orphan detection."
-                                       TextWrapping="Wrap"
-                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                        </StackPanel>
+                <Grid Grid.Row="0" Margin="24,24,24,12" ColumnDefinitions="Auto,*">
+                    <Border Grid.Column="0" Classes="icon-badge" VerticalAlignment="Top">
+                        <fi:SymbolIcon Symbol="DataTrending"/>
+                    </Border>
+                    <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" Margin="14,0,0,0">
+                        <TextBlock Text="Tenant Dashboard" Classes="page-title" Margin="0"/>
+                        <TextBlock Text="A read-only, live view of your telephony topology: auto attendants, call queues, resource accounts, phone numbers and groups — with relationships and orphan detection."
+                                   TextWrapping="Wrap"
+                                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                     </StackPanel>
-                </StackPanel>
+                </Grid>
 
                 <!-- Toolbar -->
                 <Border Grid.Row="1" Classes="sunken" Margin="24,0,24,12" Padding="16,12">
@@ -115,12 +121,17 @@
                                          MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid ColumnDefinitions="*,140,120">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" MinWidth="120"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding LanguageId}" FontSize="12"
+                                                <TextBlock Grid.Column="1" Text="{Binding LanguageId}" FontSize="12" Margin="10,0,0,0"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                                <TextBlock Grid.Column="2" Text="{Binding TimeZoneId}" FontSize="12"
-                                                           TextTrimming="CharacterEllipsis"
+                                                <TextBlock Grid.Column="2" Text="{Binding TimeZoneId}" FontSize="12" Margin="10,0,0,0"
+                                                           MaxWidth="150" TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -136,11 +147,16 @@
                                          MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid ColumnDefinitions="*,140,80">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" MinWidth="120"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding Name}" TextTrimming="CharacterEllipsis"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding RoutingMethod}" FontSize="12"
+                                                <TextBlock Grid.Column="1" Text="{Binding RoutingMethod}" FontSize="12" Margin="10,0,0,0"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                                <TextBlock Grid.Column="2" FontSize="12"
+                                                <TextBlock Grid.Column="2" FontSize="12" Margin="10,0,0,0"
                                                            Text="{Binding AgentAlertTime, StringFormat='{}{0}s'}"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
@@ -155,11 +171,16 @@
                                 <ListBox ItemsSource="{Binding ResourceAccountsView}" MaxHeight="220">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid ColumnDefinitions="*,160,110">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" MinWidth="120"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding PhoneNumber}" FontSize="12"
+                                                <TextBlock Grid.Column="1" Text="{Binding PhoneNumber}" FontSize="12" Margin="10,0,0,0"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                                                <TextBlock Grid.Column="2" Text="{Binding Kind}" FontSize="12"
+                                                <TextBlock Grid.Column="2" Text="{Binding Kind}" FontSize="12" Margin="10,0,0,0"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -173,9 +194,14 @@
                                 <ListBox ItemsSource="{Binding GroupsView}" MaxHeight="180">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid ColumnDefinitions="*,220">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" MinWidth="120"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
                                                 <TextBlock Grid.Column="0" Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding MailNickname}" FontSize="12"
+                                                <TextBlock Grid.Column="1" Text="{Binding MailNickname}" FontSize="12" Margin="10,0,0,0"
+                                                           MaxWidth="220" TextTrimming="CharacterEllipsis"
                                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -210,7 +236,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedAutoAttendantResourceAccounts}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding DisplayName}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -219,7 +245,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedAutoAttendantCallQueues}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding Name}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding Name}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -228,7 +254,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedAutoAttendantHolidayIds}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -244,7 +270,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedCallQueueResourceAccounts}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding DisplayName}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -253,7 +279,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedCallQueueGroups}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding DisplayName}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding DisplayName}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -262,7 +288,7 @@
                                     <ItemsControl ItemsSource="{Binding SelectedCallQueueAgentIds}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <TextBlock FontSize="12" Text="{Binding}"/>
+                                                <TextBlock FontSize="12" TextWrapping="Wrap" Text="{Binding}"/>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>

--- a/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/DashboardView.axaml
@@ -201,6 +201,9 @@
                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                                 <TextBlock Text="No topology loaded yet. Connect to Teams and Graph, then press Refresh."
                                            HorizontalAlignment="Center"
+                                           TextAlignment="Center"
+                                           TextWrapping="Wrap"
+                                           MaxWidth="360"
                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                             </StackPanel>
                         </StackPanel>

--- a/src/TeamsPhoneManager.Presentation/Views/DocumentationView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/DocumentationView.axaml
@@ -77,12 +77,12 @@
                         Margin="24,0,24,24"
                         Classes="sunken"
                         Padding="0">
-                    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                                   VerticalScrollBarVisibility="Auto">
                         <TextBox Text="{Binding DocumentationOutput}"
                                  IsReadOnly="True"
                                  AcceptsReturn="True"
-                                 TextWrapping="NoWrap"
+                                 TextWrapping="Wrap"
                                  FontFamily="{StaticResource CodeFontFamily}"
                                  FontSize="12"
                                  BorderThickness="0"

--- a/src/TeamsPhoneManager.Presentation/Views/HistoryView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/HistoryView.axaml
@@ -113,6 +113,8 @@
                                     <Setter Property="FontSize" Value="11"/>
                                     <Setter Property="FontWeight" Value="SemiBold"/>
                                     <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                    <!-- Right gutter so header labels never touch the next column. -->
+                                    <Setter Property="Margin" Value="0,0,12,0"/>
                                 </Style>
                             </Grid.Styles>
                             <TextBlock Grid.Column="0" Text="Time (UTC)"/>
@@ -135,6 +137,13 @@
                                                     BorderBrush="{DynamicResource HairlineBrush}"
                                                     BorderThickness="0,0,0,1">
                                                 <Grid ColumnDefinitions="150,1.1*,1.7*,1.5*,95,75">
+                                                    <Grid.Styles>
+                                                        <!-- Right gutter so wrapped cells (Operation/Target/Operator)
+                                                             can never collide with the next column. -->
+                                                        <Style Selector="TextBlock">
+                                                            <Setter Property="Margin" Value="0,0,12,0"/>
+                                                        </Style>
+                                                    </Grid.Styles>
                                                     <TextBlock Grid.Column="0" FontSize="12"
                                                                Text="{Binding TimestampUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"/>
                                                     <TextBlock Grid.Column="1" FontSize="12" TextWrapping="Wrap"

--- a/src/TeamsPhoneManager.Presentation/Views/HistoryView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/HistoryView.axaml
@@ -20,11 +20,11 @@
 
                 <!-- Header -->
                 <StackPanel Grid.Row="0" Margin="24,24,24,16">
-                    <StackPanel Orientation="Horizontal" Spacing="14" Margin="0,0,0,16">
-                        <Border Classes="icon-badge">
+                    <Grid ColumnDefinitions="Auto,*" Margin="0,0,0,16">
+                        <Border Grid.Column="0" Classes="icon-badge" VerticalAlignment="Top">
                             <fi:SymbolIcon Symbol="History"/>
                         </Border>
-                        <StackPanel Spacing="4" VerticalAlignment="Center">
+                        <StackPanel Grid.Column="1" Spacing="4" VerticalAlignment="Center" Margin="14,0,0,0">
                             <TextBlock Text="Operation History"
                                      Classes="page-title"
                                      Margin="0"/>
@@ -32,7 +32,7 @@
                                      TextWrapping="Wrap"
                                      Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                         </StackPanel>
-                    </StackPanel>
+                    </Grid>
 
                     <StackPanel Orientation="Horizontal" Spacing="12">
                         <Button Command="{Binding LoadCommand}"
@@ -107,7 +107,7 @@
                         </Grid.RowDefinitions>
 
                         <!-- Column header -->
-                        <Grid Grid.Row="0" Margin="16,10" ColumnDefinitions="150,150,*,180,90,80">
+                        <Grid Grid.Row="0" Margin="16,10" ColumnDefinitions="150,1.1*,1.7*,1.5*,95,75">
                             <Grid.Styles>
                                 <Style Selector="TextBlock">
                                     <Setter Property="FontSize" Value="11"/>
@@ -134,7 +134,7 @@
                                             <Border Padding="16,8"
                                                     BorderBrush="{DynamicResource HairlineBrush}"
                                                     BorderThickness="0,0,0,1">
-                                                <Grid ColumnDefinitions="150,150,*,180,90,80">
+                                                <Grid ColumnDefinitions="150,1.1*,1.7*,1.5*,95,75">
                                                     <TextBlock Grid.Column="0" FontSize="12"
                                                                Text="{Binding TimestampUtc, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"/>
                                                     <TextBlock Grid.Column="1" FontSize="12" TextWrapping="Wrap"
@@ -178,16 +178,18 @@
                         CornerRadius="0,0,12,12"
                         Padding="24,12"
                         Margin="0,16,0,0">
-                    <Grid ColumnDefinitions="*,Auto">
-                        <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8">
-                            <fi:SymbolIcon Symbol="Info" FontSize="14"
-                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                            <TextBlock FontSize="12"
-                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <fi:SymbolIcon Grid.Column="0" Symbol="Info" FontSize="14"
                                      VerticalAlignment="Center"
-                                     Text="{Binding AuditLogDirectory, StringFormat='Log location: {0}'}"/>
-                        </StackPanel>
+                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                         <TextBlock Grid.Column="1"
+                                 FontSize="12"
+                                 Margin="8,0,16,0"
+                                 TextTrimming="CharacterEllipsis"
+                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                 VerticalAlignment="Center"
+                                 Text="{Binding AuditLogDirectory, StringFormat='Log location: {0}'}"/>
+                        <TextBlock Grid.Column="2"
                                  FontSize="12"
                                  Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                  VerticalAlignment="Center"

--- a/src/TeamsPhoneManager.Presentation/Views/M365GroupsView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/M365GroupsView.axaml
@@ -18,7 +18,11 @@
     </UserControl.Resources>
 
     <UserControl.Styles>
-        <!-- Local styles removed, using App.axaml styles -->
+        <!-- Ellipsis-trim long values in list grids so rows stay distinguishable and the
+             rightmost column's text can never disappear under the vertical scrollbar. -->
+        <Style Selector="DataGridCell TextBlock">
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </Style>
     </UserControl.Styles>
 
     <Border Classes="card" Margin="0">

--- a/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
+++ b/src/TeamsPhoneManager.Presentation/Views/WizardView.axaml
@@ -151,11 +151,14 @@
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel Spacing="8">
-                                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                                    <fi:SymbolIcon Symbol="CheckmarkCircle" Foreground="Green" IsVisible="{Binding IsValid}"/>
-                                                    <fi:SymbolIcon Symbol="ErrorCircle" Foreground="OrangeRed" IsVisible="{Binding !IsValid}"/>
-                                                    <TextBlock Text="{Binding Label}" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                                </StackPanel>
+                                                <Grid ColumnDefinitions="Auto,*">
+                                                    <Panel Grid.Column="0" VerticalAlignment="Top" Margin="0,1,8,0">
+                                                        <fi:SymbolIcon Symbol="CheckmarkCircle" Foreground="Green" IsVisible="{Binding IsValid}"/>
+                                                        <fi:SymbolIcon Symbol="ErrorCircle" Foreground="OrangeRed" IsVisible="{Binding !IsValid}"/>
+                                                    </Panel>
+                                                    <TextBlock Grid.Column="1" Text="{Binding Label}" FontWeight="SemiBold"
+                                                               TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                                </Grid>
                                                 <ItemsControl ItemsSource="{Binding ValidationErrors}">
                                                     <ItemsControl.ItemTemplate>
                                                         <DataTemplate>
@@ -166,13 +169,17 @@
                                                 <ItemsControl ItemsSource="{Binding Objects}">
                                                     <ItemsControl.ItemTemplate>
                                                         <DataTemplate>
-                                                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="8,2,0,2">
-                                                                <fi:SymbolIcon Symbol="ChevronRight" FontSize="12" VerticalAlignment="Center"/>
-                                                                <TextBlock Text="{Binding Summary}" FontSize="12" VerticalAlignment="Center"/>
-                                                                <TextBlock Text="{Binding Upn}" FontSize="12"
-                                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                                           VerticalAlignment="Center"/>
-                                                            </StackPanel>
+                                                            <Grid ColumnDefinitions="Auto,*" Margin="8,2,0,2">
+                                                                <fi:SymbolIcon Grid.Column="0" Symbol="ChevronRight" FontSize="12"
+                                                                               VerticalAlignment="Top" Margin="0,2,8,0"/>
+                                                                <StackPanel Grid.Column="1" Spacing="1">
+                                                                    <TextBlock Text="{Binding Summary}" FontSize="12" TextWrapping="Wrap"/>
+                                                                    <TextBlock Text="{Binding Upn}" FontSize="12"
+                                                                               TextWrapping="Wrap"
+                                                                               IsVisible="{Binding Upn, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                                </StackPanel>
+                                                            </Grid>
                                                         </DataTemplate>
                                                     </ItemsControl.ItemTemplate>
                                                 </ItemsControl>
@@ -206,9 +213,16 @@
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
+                        <Grid.Styles>
+                            <!-- Restore the inter-button gap lost when the centre group became a WrapPanel. -->
+                            <Style Selector="WrapPanel#WizardActionButtons > Button">
+                                <Setter Property="Margin" Value="4"/>
+                            </Style>
+                        </Grid.Styles>
 
                         <!-- Left: Back -->
                         <Button Grid.Column="0"
+                                VerticalAlignment="Center"
                                 Command="{Binding GoToPreviousStepCommand}"
                                 IsEnabled="{Binding CanGoPrevious}">
                             <StackPanel Orientation="Horizontal" Spacing="6">
@@ -217,11 +231,13 @@
                             </StackPanel>
                         </Button>
 
-                        <!-- Center: Execute / Skip / Retry -->
-                        <StackPanel Grid.Column="1" 
-                                    Orientation="Horizontal" 
-                                    HorizontalAlignment="Center"
-                                    Spacing="8">
+                        <!-- Center: Execute / Skip / Retry — wraps to multiple rows when the width is tight
+                             instead of overflowing under the Back/Next buttons. -->
+                        <WrapPanel Grid.Column="1"
+                                   x:Name="WizardActionButtons"
+                                   Orientation="Horizontal"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center">
                             <!-- Execute Step -->
                             <Button Command="{Binding ExecuteCurrentStepCommand}"
                                     Classes="accent"
@@ -278,10 +294,11 @@
                                     <TextBlock Text="Edit Variables" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Button>
-                        </StackPanel>
+                        </WrapPanel>
 
                         <!-- Right: Next -->
                         <Button Grid.Column="2"
+                                VerticalAlignment="Center"
                                 Command="{Binding GoToNextStepCommand}"
                                 IsEnabled="{Binding CanGoNext}"
                                 Classes="accent">


### PR DESCRIPTION
## Summary

Headless visual QA of the recently added UI (History, Dashboard, dry-run preview in the wizard + bulk operations, Settings additions) surfaced text-overflow, clipping, and column-collapse defects — most severe at cramped widths (rendered at 1280x720 and 1024x640, light + realistic-and-deliberately-long data). This PR fixes them. **Presentation layer only** — no Domain/Application/Infrastructure, ScriptBuilder, or auth changes; FluentIcons kept at outline weight.

## Defects found and fixed

**History (`HistoryView.axaml`)**
- Page-header description sat in a horizontal `StackPanel`, so its wrapping `TextBlock` got infinite width and was clipped at the card's right edge instead of wrapping → moved icon + text into a `Grid` (`Auto,*`) so the description wraps.
- Record table used fixed column widths (`150,150,*,180,90,80` = 650px fixed); at 1024px the fixed columns exceeded the available width and starved the `*` **Target** column to ~0, hiding it entirely → switched header and row grids to proportional widths (`150,1.1*,1.7*,1.5*,95,75`) so every column scales.
- Footer log-path overflowed into the "Showing N" count (horizontal `StackPanel`, no trimming) → restructured to `Grid` (`Auto,*,Auto`) with `TextTrimming="CharacterEllipsis"` on the path.

**Dashboard (`DashboardView.axaml`)**
- Header description clipped at the right edge (same infinite-width `StackPanel` cause) → `Grid` (`Auto,*`).
- Auto-attendant / call-queue / resource-account / group lists collapsed the star-sized **Name** column to zero at 1024px (fixed secondary columns consumed the row), hiding the primary name entirely → gave each Name column `MinWidth="120"`, made secondary columns `Auto` with margins + `MaxWidth`/trimming, and set `ListBoxItem` `HorizontalContentAlignment="Stretch"` so rows fill their width.
- Relationships-panel item names (linked call queues, resource accounts, holiday ids) had no wrap/trim and clipped at the 360px panel edge → added `TextWrapping="Wrap"`.

**Dry-run preview — Wizard (`WizardView.axaml`)**
- Planned-object rows placed Summary + long UPN in a horizontal `StackPanel`; the UPN ran off the right edge and was clipped (no horizontal scrollbar) → restructured to `Grid` (`Auto,*`) with the UPN wrapping on its own line under the summary (hidden when empty). Entry label also now wraps.
- Step action bar overflowed: the centred button group (Execute/Skip/Dry-Run Plan/export/Edit Variables) grew wider than its column and the **Next** button overlapped **Edit Variables** (badly at 1024px) → centre group is now a `WrapPanel` that wraps to multiple rows; Back/Next stay pinned and centred, nothing overlaps.

**Dry-run preview — Bulk Operations (`BulkOperationsView.axaml`)**
- Header description clipped → `Grid` (`Auto,*`).
- Top toolbar was a non-wrapping horizontal `StackPanel`; at 1280px the **Execute All** button was clipped and at 1024px several buttons ran off-screen → converted to a `WrapPanel` (with per-button margins) so all buttons stay visible.
- Planned-object rows clipped long UPNs → same `Grid` + wrapping restructure as the wizard; entry label/row-number row moved to a `Grid` so the label wraps.

**Settings additions** (Audit Log Location row + bundled module version rows in `MainWindow.axaml`): audited in the same pass — rendered cleanly (path wraps, versions aligned), no changes needed.

## Verification
- Rendered every page above headlessly (real Skia) in empty + populated states, with 60-char queue names, long tenant/customer names and UPNs, orphan panel populated, dry-run plans generated (valid + invalid entries), and disabled/gated button states, at both 1280x720 and 1024x640. Read back every PNG and re-rendered until clean.
- Full test suite green: **542 passed / 0 failed**, including the Clean-Architecture dependency-rule tests. The existing README `ScreenshotGenerator` still passes (no-op without `GENERATE_SCREENSHOTS`).
- The temporary audit harness used to generate the review images was removed before commit (it was gated + no-op, not meant to ship); the diff is limited to the four view files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 — second headless audit (additional defects)

A follow-up independent headless audit (1280x720 and 1024x640, dark theme + light for History, deliberately long data with vertical scroll forced) surfaced further defects, now fixed. **Presentation `.axaml` only** — no Domain/Application/Infrastructure, ScriptBuilder, or auth changes; FluentIcons outline weight preserved.

**History (`HistoryView.axaml`)** — BLOCKER
- Header and populated-row grids (`150,1.1*,1.7*,1.5*,95,75`) had no column gutters; the wrapping cells (Operation/Target/Operator) butted directly into the next column, so wrapped Operator text visually merged with the Outcome value (read as "…holdings-Failure"). Added a consistent `12px` right gutter to every cell in **both** grids (via a `Grid.Styles` `TextBlock` `Margin` setter), so columns can never collide.

**List grids (`CallQueuesView.axaml`, `AutoAttendantsView.axaml`, `M365GroupsView.axaml`)**
- Long Display Names / UPNs / IDs hard-truncated with no ellipsis (rows became indistinguishable) and the rightmost column (Usage Location / ID) could run under the vertical scrollbar. Added a `DataGridCell TextBlock` → `TextTrimming="CharacterEllipsis"` style per view. Verified with 25+ rows forcing a vertical scrollbar: every long column now shows an ellipsis and the last column sits fully in its own gutter, clear of the scrollbar. The "Usage Location" header no longer clips at 1024px.

**Bulk Operations (`BulkOperationsView.axaml`)**
- Parsed Entries grid long identifiers hard-truncated with no ellipsis → same `DataGridCell TextBlock` trimming style; rows stay distinguishable.

**Dashboard (`DashboardView.axaml`)**
- Empty-state message ("No topology loaded yet. Connect to Teams and Graph, then press Refresh.") did not wrap and clipped at 1024x640 → added `TextWrapping="Wrap"`, `TextAlignment="Center"`, and `MaxWidth="360"` so it wraps, centered.

**Documentation (`DocumentationView.axaml`)**
- Empty-state monospace placeholder overflowed horizontally with a scrollbar → switched the output `TextBox` to `TextWrapping="Wrap"` and disabled the horizontal scrollbar so the placeholder wraps.

**Wizard (`WizardView.axaml`)**
- Verified the two icon-only buttons near "Dry-Run Plan" (JSON `</>` and CSV document glyphs) already have `ToolTip.Tip` set — no change needed.

### Round 2 verification
- Rebuilt a temporary headless render harness (gated on `VISUAL_AUDIT=1`, modeled on `ScreenshotGenerator`), populated the VMs with 60+ char names/UPNs and 25+ rows, and rendered History (populated, dark + light), CallQueues / AutoAttendants / M365Groups (populated), Dashboard (empty), Documentation (empty), Wizard (plan), and Bulk (Parsed Entries) at 1280x720 and 1024x640. Read back every PNG and confirmed each defect is gone (ellipsis present, no column collisions, nothing under the scrollbar, empty states wrap).
- Full test suite green: **541 passed / 0 failed**.
- The temporary harness was removed before commit; the diff is limited to the seven view files.
