### PR TITLE
ci: use generic responses API provider for AI review

### DIFF
--- a/.ai-review.conf
+++ b/.ai-review.conf
@@ -26,7 +26,13 @@
 # Model variant. Default: moonshot-v1-8k.
 # MOONSHOT_MODEL=moonshot-v1-8k
 
-# --- Generic OpenAI-compatible responses API ---
+# --- Generic OpenAI-compatible endpoint ---
+# Base URL (e.g. http://localhost:11434/v1 for Ollama, your
+# OpenAI-compatible endpoint, a vLLM instance, etc.).
+# OPENAI_COMPAT_BASE_URL=
+# OPENAI_COMPAT_MODEL=gpt-4o
+
+# --- Generic OpenAI-compatible Responses API ---
 # Base URL and model for services that expose the /responses endpoint
 # (instead of /chat/completions).
 # OPENAI_RESPONSES_BASE_URL=

--- a/.ai-review.conf
+++ b/.ai-review.conf
@@ -37,6 +37,8 @@
 # (instead of /chat/completions).
 # OPENAI_RESPONSES_BASE_URL=
 # OPENAI_RESPONSES_MODEL=gpt-5.6-sol
+# Authentication mode: bearer (default) or api-key.
+# OPENAI_RESPONSES_AUTH_MODE=bearer
 
 # --- Prompt size guard (pre-commit only) ---
 # Diff lines below this threshold skip the review unless the diff

--- a/.ai-review.conf
+++ b/.ai-review.conf
@@ -26,11 +26,11 @@
 # Model variant. Default: moonshot-v1-8k.
 # MOONSHOT_MODEL=moonshot-v1-8k
 
-# --- Generic OpenAI-compatible endpoint ---
-# Base URL (e.g. http://localhost:11434/v1 for Ollama, your Azure
-# OpenAI endpoint, a vLLM instance, etc.).
-# OPENAI_COMPAT_BASE_URL=
-# OPENAI_COMPAT_MODEL=gpt-4o
+# --- Generic OpenAI-compatible responses API ---
+# Base URL and model for services that expose the /responses endpoint
+# (instead of /chat/completions).
+# OPENAI_RESPONSES_BASE_URL=
+# OPENAI_RESPONSES_MODEL=gpt-5.6-sol
 
 # --- Prompt size guard (pre-commit only) ---
 # Diff lines below this threshold skip the review unless the diff

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -57,6 +57,7 @@ jobs:
           OPENAI_RESPONSES_BASE_URL: ${{ secrets.OPENAI_RESPONSES_BASE_URL }}
           OPENAI_RESPONSES_API_KEY: ${{ secrets.OPENAI_RESPONSES_API_KEY }}
           OPENAI_RESPONSES_MODEL: ${{ vars.OPENAI_RESPONSES_MODEL }}
+          OPENAI_RESPONSES_AUTH_MODE: api-key
         run: bash scripts/run-ai-review.sh
 
       - name: Format combined comment

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
-      AI_MODEL: ${{ vars.AI_MODEL || 'claude' }}
+      AI_MODEL: ${{ vars.AI_MODEL || 'openai-responses' }}
     permissions:
       contents: read
       pull-requests: write
@@ -54,6 +54,9 @@ jobs:
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
           MOONSHOT_MODEL: ${{ vars.MOONSHOT_MODEL }}
+          OPENAI_RESPONSES_BASE_URL: ${{ secrets.OPENAI_RESPONSES_BASE_URL }}
+          OPENAI_RESPONSES_API_KEY: ${{ secrets.OPENAI_RESPONSES_API_KEY }}
+          OPENAI_RESPONSES_MODEL: ${{ vars.OPENAI_RESPONSES_MODEL }}
         run: bash scripts/run-ai-review.sh
 
       - name: Format combined comment

--- a/app.manifest
+++ b/app.manifest
@@ -2,7 +2,7 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <!-- x-release-please-version -->
   <assemblyIdentity 
-    version="3.22.2.0"
+    version="3.23.1.0"
     name="TeamsPhoneManager"
     processorArchitecture="*"
     type="win32"/>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -91,8 +91,8 @@ echo -e "\033[32mNew version: $NEW_VERSION_SHORT (Win: $NEW_VERSION)\033[0m"
 
 # Update csproj file
 sed -i.bak "s/<Version>$CURRENT_VERSION<\/Version>/<Version>$NEW_VERSION_SHORT<\/Version>/g" "$CSPROJ_PATH"
-sed -i.bak "s/<AssemblyVersion>$CURRENT_VERSION<\/AssemblyVersion>/<AssemblyVersion>$NEW_VERSION_SHORT<\/AssemblyVersion>/g" "$CSPROJ_PATH"
-sed -i.bak "s/<FileVersion>$CURRENT_VERSION<\/FileVersion>/<FileVersion>$NEW_VERSION_SHORT<\/FileVersion>/g" "$CSPROJ_PATH"
+sed -i.bak "s/<AssemblyVersion>[0-9.]*<\/AssemblyVersion>/<AssemblyVersion>$NEW_VERSION<\/AssemblyVersion>/g" "$CSPROJ_PATH"
+sed -i.bak "s/<FileVersion>[0-9.]*<\/FileVersion>/<FileVersion>$NEW_VERSION<\/FileVersion>/g" "$CSPROJ_PATH"
 rm -f "$CSPROJ_PATH.bak"
 echo -e "\033[32m✓ Updated teams-phonemanager.csproj\033[0m"
 

--- a/scripts/invoke-model.sh
+++ b/scripts/invoke-model.sh
@@ -154,6 +154,20 @@ invoke_openai_responses() {
   : "${OPENAI_RESPONSES_BASE_URL:?OPENAI_RESPONSES_BASE_URL is required for the openai-responses provider}"
   : "${OPENAI_RESPONSES_API_KEY:?OPENAI_RESPONSES_API_KEY is required for the openai-responses provider}"
   local model="${OPENAI_RESPONSES_MODEL:-gpt-5.6-sol}"
+  local auth_mode="${OPENAI_RESPONSES_AUTH_MODE:-bearer}"
+  local auth_header
+  case "$auth_mode" in
+    bearer)
+      auth_header="Authorization: Bearer ${OPENAI_RESPONSES_API_KEY}"
+      ;;
+    api-key)
+      auth_header="api-key: ${OPENAI_RESPONSES_API_KEY}"
+      ;;
+    *)
+      echo "Unsupported OPENAI_RESPONSES_AUTH_MODE: ${auth_mode}" >&2
+      return 1
+      ;;
+  esac
   local prompt
   prompt=$(cat)
 
@@ -172,7 +186,7 @@ invoke_openai_responses() {
   local http_status
   local curl_status=0
   http_status=$(curl --silent -X POST "${OPENAI_RESPONSES_BASE_URL%/}/responses" \
-    -H "api-key: ${OPENAI_RESPONSES_API_KEY}" \
+    -H "$auth_header" \
     -H "Content-Type: application/json" \
     -d "$payload" \
     --output "$response_file" \

--- a/scripts/invoke-model.sh
+++ b/scripts/invoke-model.sh
@@ -10,8 +10,8 @@
 #   codex           OpenAI Codex CLI (npm @openai/codex, subscription auth)
 #   deepseek        DeepSeek API (OpenAI-compatible endpoint)
 #   moonshot        Moonshot/Kimi API (OpenAI-compatible endpoint)
-#   openai-compat   Generic OpenAI-compatible endpoint (bring your own base URL, /chat/completions)
-#   openai-responses  OpenAI-compatible responses API (bring your own base URL, /responses)
+#   openai-compat   Generic OpenAI-compatible endpoint (bring your own base URL)
+#   openai-responses  OpenAI-compatible Responses API (bring your own base URL)
 #
 # Reads prompt from stdin, writes review to stdout, errors to stderr.
 # Exit code reflects the underlying command's exit code.
@@ -149,11 +149,8 @@ invoke_openai_compat() {
     -d "$payload" | jq -r '.choices[0].message.content // empty'
 }
 
-# --- Provider: openai-responses (OpenAI-compatible responses API) ---
+# --- Provider: openai-responses (OpenAI-compatible Responses API) ---
 invoke_openai_responses() {
-  # Uses the /responses endpoint (not /chat/completions). Reads
-  # OPENAI_RESPONSES_BASE_URL, OPENAI_RESPONSES_API_KEY, and
-  # OPENAI_RESPONSES_MODEL from env.
   : "${OPENAI_RESPONSES_BASE_URL:?OPENAI_RESPONSES_BASE_URL is required for the openai-responses provider}"
   : "${OPENAI_RESPONSES_API_KEY:?OPENAI_RESPONSES_API_KEY is required for the openai-responses provider}"
   local model="${OPENAI_RESPONSES_MODEL:-gpt-5.6-sol}"
@@ -163,18 +160,53 @@ invoke_openai_responses() {
   local payload
   payload=$(jq -n \
     --arg model "$model" \
-    --arg content "$prompt" \
+    --arg input "$prompt" \
     '{
       model: $model,
-      input: $content,
-      temperature: 0.3,
+      input: $input,
       max_output_tokens: 4096
     }')
 
-  curl -sf -X POST "${OPENAI_RESPONSES_BASE_URL%/}/responses" \
-      -H "api-key: ${OPENAI_RESPONSES_API_KEY}" \
+  local response_file
+  response_file=$(mktemp)
+  local http_status
+  local curl_status=0
+  http_status=$(curl --silent -X POST "${OPENAI_RESPONSES_BASE_URL%/}/responses" \
+    -H "api-key: ${OPENAI_RESPONSES_API_KEY}" \
     -H "Content-Type: application/json" \
-      -d "$payload" | jq -r '.output_text // .output[0].content[0].text // empty'
+    -d "$payload" \
+    --output "$response_file" \
+    --write-out '%{http_code}') || curl_status=$?
+
+  if ((curl_status != 0)); then
+    rm -f "$response_file"
+    echo "Responses API request failed during transport." >&2
+    return 1
+  fi
+
+  if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+    rm -f "$response_file"
+    echo "Responses API request failed with HTTP status ${http_status}." >&2
+    return 1
+  fi
+
+  local output
+  if ! output=$(jq -er '
+    (
+      .output_text? //
+      ([.output[]?.content[]? | select(.type? == "output_text") | .text?]
+        | map(select(type == "string"))
+        | join("\n"))
+    )
+    | select(type == "string" and length > 0)
+  ' "$response_file"); then
+    rm -f "$response_file"
+    echo "Responses API returned no text output." >&2
+    return 1
+  fi
+
+  rm -f "$response_file"
+  printf '%s\n' "$output"
 }
 
 # --- Dispatch ---

--- a/scripts/invoke-model.sh
+++ b/scripts/invoke-model.sh
@@ -172,9 +172,9 @@ invoke_openai_responses() {
     }')
 
   curl -sf -X POST "${OPENAI_RESPONSES_BASE_URL%/}/responses" \
-    -H "Authorization: ******" \
+      -H "api-key: ${OPENAI_RESPONSES_API_KEY}" \
     -H "Content-Type: application/json" \
-    -d "$payload" | jq -r '.output[0].content[0].text // empty'
+      -d "$payload" | jq -r '.output_text // .output[0].content[0].text // empty'
 }
 
 # --- Dispatch ---

--- a/scripts/invoke-model.sh
+++ b/scripts/invoke-model.sh
@@ -10,7 +10,8 @@
 #   codex           OpenAI Codex CLI (npm @openai/codex, subscription auth)
 #   deepseek        DeepSeek API (OpenAI-compatible endpoint)
 #   moonshot        Moonshot/Kimi API (OpenAI-compatible endpoint)
-#   openai-compat   Generic OpenAI-compatible endpoint (bring your own base URL)
+#   openai-compat   Generic OpenAI-compatible endpoint (bring your own base URL, /chat/completions)
+#   openai-responses  OpenAI-compatible responses API (bring your own base URL, /responses)
 #
 # Reads prompt from stdin, writes review to stdout, errors to stderr.
 # Exit code reflects the underlying command's exit code.
@@ -148,6 +149,34 @@ invoke_openai_compat() {
     -d "$payload" | jq -r '.choices[0].message.content // empty'
 }
 
+# --- Provider: openai-responses (OpenAI-compatible responses API) ---
+invoke_openai_responses() {
+  # Uses the /responses endpoint (not /chat/completions). Reads
+  # OPENAI_RESPONSES_BASE_URL, OPENAI_RESPONSES_API_KEY, and
+  # OPENAI_RESPONSES_MODEL from env.
+  : "${OPENAI_RESPONSES_BASE_URL:?OPENAI_RESPONSES_BASE_URL is required for the openai-responses provider}"
+  : "${OPENAI_RESPONSES_API_KEY:?OPENAI_RESPONSES_API_KEY is required for the openai-responses provider}"
+  local model="${OPENAI_RESPONSES_MODEL:-gpt-5.6-sol}"
+  local prompt
+  prompt=$(cat)
+
+  local payload
+  payload=$(jq -n \
+    --arg model "$model" \
+    --arg content "$prompt" \
+    '{
+      model: $model,
+      input: $content,
+      temperature: 0.3,
+      max_output_tokens: 4096
+    }')
+
+  curl -sf -X POST "${OPENAI_RESPONSES_BASE_URL%/}/responses" \
+    -H "Authorization: ******" \
+    -H "Content-Type: application/json" \
+    -d "$payload" | jq -r '.output[0].content[0].text // empty'
+}
+
 # --- Dispatch ---
 case "$AI_MODEL" in
   claude)
@@ -168,8 +197,11 @@ case "$AI_MODEL" in
   openai-compat)
     invoke_openai_compat
     ;;
+  openai-responses)
+    invoke_openai_responses
+    ;;
   *)
-    echo "Unknown AI_MODEL: $AI_MODEL. Supported: claude, openai, codex, deepseek, moonshot, openai-compat" >&2
+    echo "Unknown AI_MODEL: $AI_MODEL. Supported: claude, openai, codex, deepseek, moonshot, openai-compat, openai-responses" >&2
     exit 1
     ;;
 esac

--- a/scripts/run-ai-review.sh
+++ b/scripts/run-ai-review.sh
@@ -37,9 +37,9 @@ if [ ! -s ai-review.txt ]; then
   {
     printf "AI review step failed (exit %d)." "$MODEL_EXIT"
     if [ -s ai-review-stderr.txt ]; then
-      printf "\n\n```\n"
+      printf '\n\n```\n'
       cat ai-review-stderr.txt
-      printf "\n```\n"
+      printf '\n```\n'
     fi
     printf "\nCheck the [repo secrets](https://github.com/%s/settings/secrets/actions) are configured for your chosen model (AI_MODEL=%s).\n" \
       "${GITHUB_REPOSITORY:-OWNER/REPO}" "${AI_MODEL:-claude}"

--- a/src/TeamsPhoneManager.Domain/ConstantsService.cs
+++ b/src/TeamsPhoneManager.Domain/ConstantsService.cs
@@ -51,7 +51,7 @@ namespace teams_phonemanager.Services
 
         public static class Application
         {
-            public const string Version = "Version 3.23.0"; // x-release-please-version
+            public const string Version = "Version 3.23.1"; // x-release-please-version
             public const string Copyright = "Patrik Lleshaj © 2026. MIT License.";
         }
 

--- a/src/TeamsPhoneManager.Infrastructure/TeamsPhoneManager.Infrastructure.csproj
+++ b/src/TeamsPhoneManager.Infrastructure/TeamsPhoneManager.Infrastructure.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.Management.Automation" Version="7.6.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
     <!-- Transitive dependency override to resolve a known vulnerability pulled via PowerShell.SDK -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/teams-phonemanager.csproj
+++ b/teams-phonemanager.csproj
@@ -5,9 +5,9 @@
          EnableNETAnalyzers and AnalysisLevel are inherited from Directory.Build.props. -->
     <OutputType>WinExe</OutputType>
     <RootNamespace>teams_phonemanager</RootNamespace>
-    <Version>3.23.0</Version> <!-- x-release-please-version -->
-    <AssemblyVersion>3.23.0.0</AssemblyVersion> <!-- x-release-please-version -->
-    <FileVersion>3.23.0.0</FileVersion> <!-- x-release-please-version -->
+    <Version>3.23.1</Version> <!-- x-release-please-version -->
+    <AssemblyVersion>3.23.1.0</AssemblyVersion> <!-- x-release-please-version -->
+    <FileVersion>3.23.1.0</FileVersion> <!-- x-release-please-version -->
     
     <!-- Publish Settings for Framework-Dependent Deployment -->
     <PublishSingleFile>false</PublishSingleFile>
@@ -42,7 +42,7 @@
     <PackageReference Include="System.IO.Packaging" Version="10.0.6" />
     <PackageReference Include="System.Management.Automation" Version="7.6.0" />
     <!-- Transitive dependency overrides to resolve known vulnerabilities -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
Replaces the default AI review model from Claude to a generic responses API provider (`openai-responses`). The new provider talks to the OpenAI v1 `/responses` endpoint (not `/chat/completions`) with the corresponding request/response shape.

## Changes
- **`scripts/invoke-model.sh`** — Added `invoke_openai_responses()` function that sends `input` + `max_output_tokens` and reads from `output[0].content[0].text`
- **`.github/workflows/ai-review.yml`** — Default `AI_MODEL` changed to `openai-responses`; added env var mappings for `OPENAI_RESPONSES_BASE_URL`, `OPENAI_RESPONSES_API_KEY`, and `OPENAI_RESPONSES_MODEL`
- **`.ai-review.conf`** — Added documentation for the new provider options

## Verification
- [x] Dispatch added to `invoke-model.sh`
- [x] CI workflow defaults to the new provider
- [x] Repo secrets and variable configured via `gh` CLI

The Claude provider remains wired and can be selected by changing the `AI_MODEL` default back to `claude`.