### PR TITLE
ci: default AI review back to Claude subscription

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
-      AI_MODEL: ${{ vars.AI_MODEL || 'openai-responses' }}
+      AI_MODEL: ${{ vars.AI_MODEL || 'claude' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Flips the `AI_MODEL` workflow default from `openai-responses` back to `claude` (Claude Code CLI with the `CLAUDE_CODE_OAUTH_TOKEN` subscription secret, as before PR #151). The responses-API provider code and its secrets stay in place — selectable anytime by setting the `AI_MODEL` repo variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)