### PR TITLE
ci: upgrade all GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Checkout release commit
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         # Draft GitHub releases do not create their tag until publication.
         ref: ${{ needs.release-please.outputs.release_sha }}
@@ -138,12 +138,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ needs.release-please.outputs.release_sha }}
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
     
@@ -220,7 +220,7 @@ jobs:
         zip -r ../../dist/phonedesk-linux-x64.zip .
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: phonedesk-${{ matrix.runtime }}
         path: ./dist/*
@@ -237,7 +237,7 @@ jobs:
     steps:
     - name: Download all artifacts
       # Build jobs upload finished assets (zips / setup exe), so a flat merge is enough.
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: phonedesk-*
         path: ./artifacts
@@ -285,7 +285,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     steps:
     - name: Checkout tap
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: realgarit/homebrew-tap
         token: ${{ secrets.PAT_TOKEN }}
@@ -371,14 +371,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         # For PR events, use the head SHA (not the merge ref) to avoid race
         # where the merge ref is deleted before the runner picks up the job.
         ref: ${{ inputs.validate_ref || github.event.pull_request.head.sha || github.ref }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 

--- a/.github/workflows/module-compatibility.yml
+++ b/.github/workflows/module-compatibility.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
@@ -112,8 +112,8 @@ jobs:
 
           Build/test output:
 
-          \`\`\`
+          $(printf '```')
           $(tail -c 20000 "$RUNNER_TEMP/build-output.log" 2>/dev/null || echo "No output captured.")
-          \`\`\`
+          $(printf '```')
           EOF
           )"


### PR DESCRIPTION
## What

Upgrades every GitHub Action in the repo from Node 20 to Node 24 runtimes.

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` (×4) + 2 SHA-pinned | `@v7` |
| `actions/setup-dotnet` | `@v4` (×2) + 1 SHA-pinned | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |

Also fixes a backtick-in-heredoc issue in `module-compatibility.yml` where literal `` \`\`\` `` strings were being interpreted as empty command substitutions.

## Verification

- Zero `@v4` references remain under `.github/`
- Zero Node 20 SHA-pinned actions remain
- All Node 24 versions confirmed against each action's `action.yml` `runs.using` field
- `module-compatibility.yml` backtick fix uses `$(printf '```')` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
